### PR TITLE
Better log file management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(MavlinkTagController2
     Telemetry.cpp Telemetry.h
     PulseSimulator.cpp PulseSimulator.h
     timeHelpers.cpp timeHelpers.h
+    LogFileManager.cpp LogFileManager.h
 )
 
 target_include_directories(MavlinkTagController2

--- a/CommandHandler.h
+++ b/CommandHandler.h
@@ -11,6 +11,7 @@ namespace bp = boost::process;
 
 class MavlinkSystem;
 class MonitoredProcess;
+class LogFileManager;
 
 class CommandHandler {
 public:
@@ -25,7 +26,7 @@ private:
     bool _handleStopDetection   (void);
     bool _handleRawCapture      (const mavlink_tunnel_t& tunnel);
     void _handleTunnelMessage   (const mavlink_message_t& message);
-    void _startDetector         (const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel);
+    void _startDetector         (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel);
 
     std::string _tunnelCommandIdToString    (uint32_t command);
     std::string _tunnelCommandResultToString(uint32_t result);
@@ -37,6 +38,5 @@ private:
     uint32_t                        _receivingTagsSdrType;
     char*                           _homePath               = NULL;
     std::vector<MonitoredProcess*>  _processes;
-    uint                            _startCount             = 0;
     bp::pipe*                       _airspyPipe             = NULL;
 };

--- a/LogFileManager.cpp
+++ b/LogFileManager.cpp
@@ -1,0 +1,33 @@
+#include "LogFileManager.h"
+#include "formatString.h"
+
+#include <stdlib.h>
+#include <filesystem>
+
+LogFileManager* LogFileManager::_instance = nullptr;
+
+LogFileManager* LogFileManager::instance()
+{
+    if (_instance == nullptr) {
+        _instance = new LogFileManager();
+    }
+    return _instance;
+}
+
+LogFileManager::LogFileManager()
+{
+    _logDir = std::string(getenv("HOME")) + "/Logs";
+}
+
+void LogFileManager::detectorsStarted()
+{
+    if (_detectorStartIndex++ == 0) {
+        std::filesystem::remove_all(_logDir);
+        std::filesystem::create_directory(_logDir);
+    }
+}
+
+std::string LogFileManager::filename(const char* root, const char* extension)
+{
+    return formatString("%s/%s.%d.%s", _logDir.c_str(), root, _detectorStartIndex, extension);
+}

--- a/LogFileManager.h
+++ b/LogFileManager.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+class LogFileManager
+{
+public:
+	static LogFileManager* instance();
+
+	void 		detectorsStarted();
+	std::string filename(const char* root, const char* extension);
+	std::string logDir() const { return _logDir; }
+	int 		detectorStartIndex() const { return _detectorStartIndex; }
+
+private:
+	LogFileManager();
+	
+	int 		_detectorStartIndex = 0;
+	std::string _logDir;
+
+	static LogFileManager* _instance;
+};


### PR DESCRIPTION
* Fixes #14
* All log files (except controller) are now written to the `~/Logs` directory
* All log files use the `*.#.*` naming convention where `#` is the detector start index
* For logs which are also associated with a tag id the naming convention is `*_id.#.*` where `id` is the tag id
* The Logs directory is cleaned of previous log files when the first start detection happens
* Config files now include `logPath` and `startIndex` entries

Here is a screenshot of the Logs directory after two start/stops on the detectors:
![Screen Shot 2023-09-23 at 10 35 37 AM](https://github.com/DonLakeFlyer/MavlinkTagController2/assets/5876851/b60b0072-7a89-4c1f-b21c-5cdf31e0ab0a)

New config file entries:
```
##################################################
ID:	2
channelCenterFreqMHz:	146.000000
ipData:	127.0.0.1
portData:	20000
Fs:	3750
tagFreqMHz:	146.000000
tp:	0.015000
tip:	1.333000
tipu:	0.060000
tipj:	0.020000
K:	3
opMode:	freqSearchHardLock
excldFreqs:	[Inf, -Inf]
falseAlarmProb:	0.010000
dataRecordPath:	/home/vmware/Logs/data_record_2.1.bin
logPath:	/home/vmware/Logs
startIndex:	1
ipCntrl:	127.0.0.1
portCntrl:	30000
processedOuputPath:	/home/vmware/Logs
ros2enable:	false
startInRunState:	true
timeStamp:	1646403180.469
```
