### PR TITLE
Keep 10 flight log runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(MavlinkTagController2)
 
 add_definitions("-Wall -Wextra -Wno-address-of-packed-member")
 
+set(Boost_USE_MULTITHREADED ON) 
+find_package( Boost REQUIRED COMPONENTS system filesystem )
+
 add_executable(MavlinkTagController2
     main.cpp
     channelizerTuner.cpp channelizerTuner.h
@@ -35,4 +38,9 @@ target_include_directories(MavlinkTagController2
     PRIVATE
     uavrt_interfaces/include/uavrt_interfaces
     mavlink/v2/common
+)
+
+target_link_libraries(MavlinkTagController2
+    PRIVATE
+    ${Boost_LIBRARIES}
 )

--- a/LogFileManager.cpp
+++ b/LogFileManager.cpp
@@ -1,10 +1,16 @@
 #include "LogFileManager.h"
 #include "formatString.h"
+#include "log.h"
 
 #include <stdlib.h>
-#include <filesystem>
+#include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
 
-LogFileManager* LogFileManager::_instance = nullptr;
+namespace bf = boost::filesystem;
+namespace bs = boost::system;
+
+LogFileManager* LogFileManager::_instance       = nullptr;
+const char* 	LogFileManager::_logDirPrefix   = "Logs";
 
 LogFileManager* LogFileManager::instance()
 {
@@ -16,14 +22,22 @@ LogFileManager* LogFileManager::instance()
 
 LogFileManager::LogFileManager()
 {
-    _logDir = std::string(getenv("HOME")) + "/Logs";
+    _homeDir    = std::string(getenv("HOME"));
+    _logDir     = formatString("%s/%s_1", _homeDir.c_str(), _logDirPrefix);
 }
 
 void LogFileManager::detectorsStarted()
 {
     if (_detectorStartIndex++ == 0) {
-        std::filesystem::remove_all(_logDir);
-        std::filesystem::create_directory(_logDir);
+        bs::error_code errorCode;
+        
+        for (int i=10; i>=1; i--) {
+            auto oldName = formatString("%s/%s_%d", _homeDir.c_str(), _logDirPrefix, i);
+            auto newName = formatString("%s/%s_%d", _homeDir.c_str(), _logDirPrefix, i + 1);
+            bf::rename(oldName.c_str(), newName.c_str(), errorCode);
+        }
+
+        bf::create_directory(_logDir.c_str(), errorCode);
     }
 }
 

--- a/LogFileManager.h
+++ b/LogFileManager.h
@@ -16,7 +16,9 @@ private:
 	LogFileManager();
 	
 	int 		_detectorStartIndex = 0;
+	std::string _homeDir;
 	std::string _logDir;
 
-	static LogFileManager* _instance;
+	static LogFileManager* 	_instance;
+	static const char* 		_logDirPrefix;
 };


### PR DESCRIPTION
When you tell the controller to start detectors for the first time in that run:
* The log directories named `Log_#` are moved down one slot. So for example `Log_1` is renamed `Log_2`, `Log_2` is renamed `Log_3`
* There are a maximum of 10 log directories, `Log_10` will be lost on a fresh controller start detection
* `Log_1` is always the newest flight