### PR TITLE
Support custom airspy command line

### DIFF
--- a/CommandHandler.h
+++ b/CommandHandler.h
@@ -39,4 +39,5 @@ private:
     char*                           _homePath               = NULL;
     std::vector<MonitoredProcess*>  _processes;
     bp::pipe*                       _airspyPipe             = NULL;
+    std::string                     _airspyCmdLine;
 };


### PR DESCRIPTION
* By default the airspy command line will include `-h 21 -t 0`
* You can override this by creating a file named `~/airspy_cmdline.txt`
* The contents of the file should only be what you want the command line to be. For example `-h 10 -t 0` to lower the gain.
* The controller log file will report what the override is