### PR TITLE
New logging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,8 @@
         "numbers": "cpp",
         "semaphore": "cpp",
         "stop_token": "cpp",
-        "any": "cpp"
+        "any": "cpp",
+        "forward_list": "cpp",
+        "unordered_set": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,12 @@
         "typeindex": "cpp",
         "typeinfo": "cpp",
         "variant": "cpp",
-        "csignal": "cpp"
+        "csignal": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "numbers": "cpp",
+        "semaphore": "cpp",
+        "stop_token": "cpp",
+        "any": "cpp"
     }
 }

--- a/CommandHandler.cpp
+++ b/CommandHandler.cpp
@@ -174,7 +174,6 @@ bool CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel)
         memcpy(&startDetection, tunnel.payload, sizeof(startDetection));
 
         logInfo() << "COMMAND_ID_START_DETECTION:";
-        logInfo() << "\tdetectorStartIndex:"        << logFileManager->detectorStartIndex(); 
         logInfo() << "\tradio_center_frequency_hz:" << startDetection.radio_center_frequency_hz; 
         logInfo() << "\tsdr_type:"                  << startDetection.sdr_type; 
 
@@ -275,10 +274,15 @@ bool CommandHandler::_handleStopDetection(void)
             process->stop();
         }
         _processes.clear();
+
         delete _airspyPipe;
         _airspyPipe = NULL;
+
         _mavlink->setHeartbeatStatus(HEARTBEAT_STATUS_HAS_TAGS);
         _mavlink->sendStatusText("#Detectors stopped", MAV_SEVERITY_INFO);
+
+        auto logFileManager = LogFileManager::instance();
+        logFileManager->detectorsStopped();
     }).detach();
 
     return true;

--- a/LogFileManager.cpp
+++ b/LogFileManager.cpp
@@ -2,7 +2,9 @@
 #include "formatString.h"
 #include "log.h"
 
-#include <stdlib.h>
+#include <chrono>
+#include <iomanip>
+
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -22,41 +24,32 @@ LogFileManager* LogFileManager::instance()
 
 LogFileManager::LogFileManager()
 {
-    _homeDir    = std::string(getenv("HOME"));
-    _logDir     = formatString("%s/%s_1", _homeDir.c_str(), _logDirPrefix);
+    _homeDir = std::string(getenv("HOME"));
 }
 
 void LogFileManager::detectorsStarted()
 {
-    if (_detectorStartIndex++ == 0) {
-        bs::error_code errorCode;
-        
-        for (int i=10; i>=1; i--) {
-            auto oldName = formatString("%s/%s_%d", _homeDir.c_str(), _logDirPrefix, i);
-            auto newName = formatString("%s/%s_%d", _homeDir.c_str(), _logDirPrefix, i + 1);
+    auto now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    auto now_utc    = *std::gmtime(&now_time_t);
 
-            if (bf::exists(newName, errorCode)) {
-                logDebug() << "Removing " << newName;
-                bf::remove_all(newName, errorCode);
-                if (errorCode) {
-                    logDebug() << "Failed to remove " << newName << ": " << errorCode.message();
-                }
-            }
-            
-            bf::rename(oldName.c_str(), newName.c_str(), errorCode);
-            if (errorCode) {
-                logDebug() << "Failed to rename " << oldName << " to " << newName << ": " << errorCode.message();
-            }
-        }
+    char buffer[80];
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M", &now_utc);
 
-        bf::create_directory(_logDir.c_str(), errorCode);
-        if (errorCode) {
-            logDebug() << "Failed to create directory " << _logDir << ": " << errorCode.message();
-        }
+    _logDir = formatString("%s-%s", _logDirPrefix, buffer);
+
+    bs::error_code errorCode;
+    bf::create_directory(_logDir.c_str(), errorCode);
+    if (errorCode) {
+        logDebug() << "Failed to create directory " << _logDir << ": " << errorCode.message();
     }
+}
+
+void LogFileManager::detectorsStopped()
+{
+
 }
 
 std::string LogFileManager::filename(const char* root, const char* extension)
 {
-    return formatString("%s/%s.%d.%s", _logDir.c_str(), root, _detectorStartIndex, extension);
+    return formatString("%s/%s.%s", _logDir.c_str(), root, extension);
 }

--- a/LogFileManager.cpp
+++ b/LogFileManager.cpp
@@ -29,13 +29,15 @@ LogFileManager::LogFileManager()
 
 void LogFileManager::detectorsStarted()
 {
+    _detectorsRunning = true;
+
     auto now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     auto now_utc    = *std::gmtime(&now_time_t);
 
     char buffer[80];
     std::strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M", &now_utc);
 
-    _logDir = formatString("%s-%s", _logDirPrefix, buffer);
+    _logDir = formatString("%s/%s-%s", _homeDir.c_str(), _logDirPrefix, buffer);
 
     bs::error_code errorCode;
     bf::create_directory(_logDir.c_str(), errorCode);
@@ -46,7 +48,7 @@ void LogFileManager::detectorsStarted()
 
 void LogFileManager::detectorsStopped()
 {
-
+    _detectorsRunning = false;
 }
 
 std::string LogFileManager::filename(const char* root, const char* extension)

--- a/LogFileManager.h
+++ b/LogFileManager.h
@@ -8,14 +8,14 @@ public:
 	static LogFileManager* instance();
 
 	void 		detectorsStarted();
+	void 		detectorsStopped();
+
 	std::string filename(const char* root, const char* extension);
 	std::string logDir() const { return _logDir; }
-	int 		detectorStartIndex() const { return _detectorStartIndex; }
 
 private:
 	LogFileManager();
 	
-	int 		_detectorStartIndex = 0;
 	std::string _homeDir;
 	std::string _logDir;
 

--- a/LogFileManager.h
+++ b/LogFileManager.h
@@ -9,6 +9,7 @@ public:
 
 	void 		detectorsStarted();
 	void 		detectorsStopped();
+    bool        detectorsRunning() const { return _detectorsRunning; }
 
 	std::string filename(const char* root, const char* extension);
 	std::string logDir() const { return _logDir; }
@@ -18,6 +19,7 @@ private:
 	
 	std::string _homeDir;
 	std::string _logDir;
+    bool        _detectorsRunning = false;
 
 	static LogFileManager* 	_instance;
 	static const char* 		_logDirPrefix;

--- a/MavlinkSystem.cpp
+++ b/MavlinkSystem.cpp
@@ -173,14 +173,18 @@ void MavlinkSystem::_logCPUTemp()
     float               temp = 0.0;
 
     stream.open(fileName);
-    buffer << stream.rdbuf();
-    stream.close();
+    if (stream.is_open()) {
+        buffer << stream.rdbuf();
+        stream.close();
 
-    temp = std::stof(buffer.str());     // convert string to float
-    temp = temp / 1000;                 // convert float value to degree
-    temp = roundf(temp * 100) / 100;    // round decimal to nearest  
+        temp = std::stof(buffer.str());     // convert string to float
+        temp = temp / 1000;                 // convert float value to degree
+        temp = roundf(temp * 100) / 100;    // round decimal to nearest  
 
-    logDebug() << "CPU Temperature: " << temp << "°C";    
+        logDebug() << "CPU Temperature: " << temp << "°C";
+    } else {
+        logError() << "Failed to open CPU temperature file";
+    }
 }
 
 void MavlinkSystem::startTunnelHeartbeatSender()

--- a/MonitoredProcess.cpp
+++ b/MonitoredProcess.cpp
@@ -73,7 +73,9 @@ void MonitoredProcess::_run(void)
 				break;
 		}
 	} catch(bp::process_error& e) {
-		logError() << "MonitoredProcess::run boost::process:child threw process_error exception -" << e.what();
+		logError() << "MonitoredProcess::run boost::process:child threw process_error exception\n" 
+            << "\terror: " << e.what() << "\n"
+            << "\tcommand: " << _command;
 		_terminated = true;
 //		} catch(...) {
 //			std::cout << "MonitoredProcess::run boost::process:child threw unknown exception" << std::endl;

--- a/TagDatabase.cpp
+++ b/TagDatabase.cpp
@@ -56,9 +56,9 @@ bool TagDatabase::_writeDetectorConfig(const TunnelProtocol::TagInfo_t& tagInfo,
     fprintf(fp, "opMode:\tfreqSearchHardLock\n");
     fprintf(fp, "excldFreqs:\t[Inf, -Inf]\n");
     fprintf(fp, "falseAlarmProb:\t%f\n",                        tagInfo.false_alarm_probability);
-    fprintf(fp, "dataRecordPath:\t%s/data_record_%d.%d.bin\n",  logFileManager->logDir().c_str(), tagId, logFileManager->detectorStartIndex());
+    fprintf(fp, "dataRecordPath:\t%s/data_record_%d.bin\n",     logFileManager->logDir().c_str(), tagId);
     fprintf(fp, "logPath:\t%s\n",                               logFileManager->logDir().c_str());
-    fprintf(fp, "startIndex:\t%d\n",                            logFileManager->detectorStartIndex());
+    fprintf(fp, "startIndex:\t%d\n",                            1);
     fprintf(fp, "ipCntrl:\t127.0.0.1\n");
     fprintf(fp, "portCntrl:\t30000\n");
     fprintf(fp, "processedOuputPath:\t%s\n",                    logFileManager->logDir().c_str());

--- a/log.cpp
+++ b/log.cpp
@@ -9,6 +9,68 @@
 
 std::mutex LogDetailed::_logMutex;
 
+LogDetailed::LogDetailed(const char* filename, int filenumber) 
+    : _s                ()
+    , _caller_filename  (filename)
+    , _caller_filenumber(filenumber)
+{
+
+}
+
+LogDetailed::~LogDetailed()
+{
+
+    switch (_log_level) {
+        case LogLevel::Debug:
+            set_color(LogColor::Green);
+            break;
+        case LogLevel::Info:
+            set_color(LogColor::Blue);
+            break;
+        case LogLevel::Warn:
+            set_color(LogColor::Yellow);
+            break;
+        case LogLevel::Err:
+            set_color(LogColor::Red);
+            break;
+    }
+
+    _logMutex.lock();
+
+    // Time output taken from:
+    // https://stackoverflow.com/questions/16357999#answer-16358264
+    time_t rawtime;
+    time(&rawtime);
+    struct tm* timeinfo = localtime(&rawtime);
+    char time_buffer[10]{}; // We need 8 characters + \0
+    strftime(time_buffer, sizeof(time_buffer), "%I:%M:%S", timeinfo);
+    std::cout << "[" << time_buffer;
+
+    switch (_log_level) {
+        case LogLevel::Debug:
+            std::cout << "|D] ";
+            break;
+        case LogLevel::Info:
+            std::cout << "|I] ";
+            break;
+        case LogLevel::Warn:
+            std::cout << "|W] ";
+            break;
+        case LogLevel::Err:
+            std::cout << "|E] ";
+            break;
+    }
+
+    set_color(LogColor::Reset);
+
+    std::cout << _s.str();
+    std::cout << " (" << _caller_filename << ":" << std::dec << _caller_filenumber << ")";
+
+    std::cout << std::endl;
+
+    _logMutex.unlock();
+}
+
 void set_color(LogColor LogColor)
 {
     switch (LogColor) {

--- a/log.h
+++ b/log.h
@@ -25,11 +25,12 @@ void set_color(LogColor LogColor);
 
 class LogDetailed {
 public:
-    LogDetailed(const char* filename, int filenumber) :
-        _s(),
-        _caller_filename(filename),
-        _caller_filenumber(filenumber)
-    {}
+    LogDetailed(const char* filename, int filenumber);
+    LogDetailed(const LogDetailed&) = delete;
+
+    virtual ~LogDetailed();
+
+    void operator=(const LogDetailed&) = delete;
 
     LogDetailed& operator<<(uint8_t& x)
     {
@@ -51,63 +52,6 @@ public:
         return *this;
     }
 
-    virtual ~LogDetailed()
-    {
-
-        switch (_log_level) {
-            case LogLevel::Debug:
-                set_color(LogColor::Green);
-                break;
-            case LogLevel::Info:
-                set_color(LogColor::Blue);
-                break;
-            case LogLevel::Warn:
-                set_color(LogColor::Yellow);
-                break;
-            case LogLevel::Err:
-                set_color(LogColor::Red);
-                break;
-        }
-
-        _logMutex.lock();
-
-        // Time output taken from:
-        // https://stackoverflow.com/questions/16357999#answer-16358264
-        time_t rawtime;
-        time(&rawtime);
-        struct tm* timeinfo = localtime(&rawtime);
-        char time_buffer[10]{}; // We need 8 characters + \0
-        strftime(time_buffer, sizeof(time_buffer), "%I:%M:%S", timeinfo);
-        std::cout << "[" << time_buffer;
-
-        switch (_log_level) {
-            case LogLevel::Debug:
-                std::cout << "|D] ";
-                break;
-            case LogLevel::Info:
-                std::cout << "|I] ";
-                break;
-            case LogLevel::Warn:
-                std::cout << "|W] ";
-                break;
-            case LogLevel::Err:
-                std::cout << "|E] ";
-                break;
-        }
-
-        set_color(LogColor::Reset);
-
-        std::cout << _s.str();
-        std::cout << " (" << _caller_filename << ":" << std::dec << _caller_filenumber << ")";
-
-        std::cout << std::endl;
-
-        _logMutex.unlock();
-    }
-
-    LogDetailed(const LogDetailed&) = delete;
-    void operator=(const LogDetailed&) = delete;
-
 protected:
     LogLevel _log_level = LogLevel::Debug;
 
@@ -121,7 +65,8 @@ private:
 
 class LogDebugDetailed : public LogDetailed {
 public:
-    LogDebugDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
+    LogDebugDetailed(const char* filename, int filenumber) 
+        : LogDetailed(filename, filenumber)
     {
         _log_level = LogLevel::Debug;
     }
@@ -129,7 +74,8 @@ public:
 
 class LogInfoDetailed : public LogDetailed {
 public:
-    LogInfoDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
+    LogInfoDetailed(const char* filename, int filenumber) 
+        : LogDetailed(filename, filenumber)
     {
         _log_level = LogLevel::Info;
     }
@@ -137,7 +83,8 @@ public:
 
 class LogWarnDetailed : public LogDetailed {
 public:
-    LogWarnDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
+    LogWarnDetailed(const char* filename, int filenumber) 
+        : LogDetailed(filename, filenumber)
     {
         _log_level = LogLevel::Warn;
     }
@@ -145,7 +92,8 @@ public:
 
 class LogErrDetailed : public LogDetailed {
 public:
-    LogErrDetailed(const char* filename, int filenumber) : LogDetailed(filename, filenumber)
+    LogErrDetailed(const char* filename, int filenumber) 
+        : LogDetailed(filename, filenumber)
     {
         _log_level = LogLevel::Err;
     }

--- a/log.h
+++ b/log.h
@@ -21,7 +21,7 @@
 enum class LogColor { Red, Green, Yellow, Blue, Gray, Reset };
 enum class LogLevel : int { Debug = 0, Info = 1, Warn = 2, Err = 3 };
 
-void set_color(LogColor LogColor);
+void set_color(LogColor LogColor, std::stringstream& s);
 
 class LogDetailed {
 public:


### PR DESCRIPTION
* Log files are now written to a directory which is named based on date and UTC time. Example: ```Logs-2024-01-09_21-04```
* Each time you start detectors a new directory is created. Only a single detection run is in a log directory.
* The controller continues to write a full log file in the home directory
* The controller now also writes a log file to the new log directory. This will contain the controller logs which were output in between the start/stop detection command

Still to do:
* Send the Log name back to QGC in the Ack for the start detection command
* Use this log naming scheme to name the various csv pulse files associated with start/stop detection
* This make it easier to connect both sets of logs back together after the fact