### PR TITLE
Add AirSpy HF support with airspyhf_decimator pipeline

### DIFF
--- a/TagDatabase.h
+++ b/TagDatabase.h
@@ -12,9 +12,9 @@ public:
     TagDatabase() = default;
 
     std::string detectorConfigFileName  (const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel) const;
-    bool        writeDetectorConfigs    () const;
+    bool        writeDetectorConfigs    (bool isHFMode) const;
     std::string channelizerCommandLine  () const;
 
 private:
-    bool        _writeDetectorConfig    (const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel) const;
+    bool        _writeDetectorConfig    (const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode) const;
 };


### PR DESCRIPTION
- Update detector config to use 3840 Hz sample rate for HF mode (vs 3750 Hz for Mini)
- Configure HF detectors to use UDP ports 10000/10001 (vs channelizer ports 20000+ for Mini)
- Implement HF pipeline: airspyhf_rx -> airspyhf_decimator -> detectors (bypasses channelizer)
- Add 10 kHz frequency offset to avoid HF DC spike, compensated by decimator --shift-khz option
- Pass device type through to detector config generation