### PR TITLE
Add shared TagTrackerWireFormat submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "mavlink/v2"]
 	path = mavlink/v2
 	url = https://github.com/mavlink/c_library_v2.git
+[submodule "TagTrackerWireFormat"]
+	path = TagTrackerWireFormat
+	url = https://github.com/DonLakeFlyer/TagTrackerWireFormat.git

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 
 Protocol, packet-format, timing, and sample-rate assumption changes must be coordinated across all three repositories.
 
+This repository also tracks the shared wire-format module as a submodule:
+
+```
+git submodule update --init --recursive
+```
+
 ## Configure GitHub login for repo access
 
 Setup auth for *https* connections.


### PR DESCRIPTION
## Summary
- add `TagTrackerWireFormat` as a tracked submodule in the controller repo
- document submodule initialization in README to keep cross-repo setup consistent

## Validation
- repo updates are documentation/submodule-reference only

## Cross-repo impact
- Keeps controller repo aligned with shared protocol module used by publisher and decimator repos.