### PR TITLE
feat: add --debug flag to pulse detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ airspyhf_channelize
 *.asv
 double2singlecomplex.m
 singlecomplex2double.m
+
+# Python
+__pycache__/
+*.pyc

--- a/detector/run_detector.sh
+++ b/detector/run_detector.sh
@@ -89,5 +89,6 @@ python3 -u "$DET" \
     --tip "$TIP" \
     --port "$UDP_PORT" \
     --center-freq "$TAG_CENTER" \
+    "$@" \
     2>&1 | sed -u 's/^/[det] /'
 


### PR DESCRIPTION
## Summary
- Adds `--debug` CLI flag to `pulse_detector.py` that prints diagnostics at each pipeline stage: W matrix health, STFT power stats, noise estimation, EVT threshold, score/threshold ratios, and top-5 candidate frequency bins
- Updates `run_detector.sh` to forward extra args (`"$@"`) to the detector, so `./run_detector.sh --debug` works

## Test plan
- [ ] Run `./detector/run_detector.sh --debug` and verify diagnostic output appears
- [ ] Run without `--debug` and verify no extra output
- [ ] Check `[DEBUG THRESH] score/threshold ratio` to identify why detections are failing