### PR TITLE
Remove component build options; require system libairspyhf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,36 @@ permissions:
   contents: read
 
 jobs:
-  # ── Controller build ───────────────────────────────────────────────
-  controller:
+  # ── Full build + test ──────────────────────────────────────────────
+  build:
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-24.04
-            install_deps: sudo apt-get update && sudo apt-get install -y libboost-system-dev libboost-thread-dev
+            preset: debug
+            install_deps: >-
+              sudo apt-get update && sudo apt-get install -y
+              build-essential cmake pkg-config
+              libboost-system-dev libboost-thread-dev libboost-filesystem-dev
+              libzmq3-dev libusb-1.0-0-dev libairspyhf-dev
+          - os: ubuntu-24.04
+            preset: release
+            install_deps: >-
+              sudo apt-get update && sudo apt-get install -y
+              build-essential cmake pkg-config
+              libboost-system-dev libboost-thread-dev libboost-filesystem-dev
+              libzmq3-dev libusb-1.0-0-dev libairspyhf-dev
           - os: macos-latest
-            install_deps: brew install boost
+            preset: debug
+            install_deps: brew install cmake pkg-config boost zeromq libusb airspyhf
+          - os: macos-latest
+            preset: release
+            install_deps: brew install cmake pkg-config boost zeromq libusb airspyhf
 
+    name: build (${{ matrix.os }}, ${{ matrix.preset }})
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,133 +49,14 @@ jobs:
         run: ${{ matrix.install_deps }}
 
       - name: Configure
-        run: cmake --preset controller
-
-      - name: Build controller
-        run: cmake --build --preset controller
-
-  # ── Decimator build + test ─────────────────────────────────────────
-  decimator:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Ubuntu: gcc + clang, Debug + Release
-          - os: ubuntu-24.04
-            build_type: Debug
-            compiler: gcc
-            cxx: g++
-            install_deps: sudo apt-get update && sudo apt-get install -y libzmq3-dev pkg-config
-          - os: ubuntu-24.04
-            build_type: Release
-            compiler: gcc
-            cxx: g++
-            install_deps: sudo apt-get update && sudo apt-get install -y libzmq3-dev pkg-config
-          - os: ubuntu-24.04
-            build_type: Debug
-            compiler: clang
-            cxx: clang++
-            install_deps: sudo apt-get update && sudo apt-get install -y libzmq3-dev pkg-config
-          - os: ubuntu-24.04
-            build_type: Release
-            compiler: clang
-            cxx: clang++
-            install_deps: sudo apt-get update && sudo apt-get install -y libzmq3-dev pkg-config
-          # macOS: Apple Clang, Debug + Release
-          - os: macos-latest
-            build_type: Debug
-            compiler: clang
-            cxx: clang++
-            install_deps: brew install zeromq pkg-config
-          - os: macos-latest
-            build_type: Release
-            compiler: clang
-            cxx: clang++
-            install_deps: brew install zeromq pkg-config
-
-    name: decimator (${{ matrix.os }}, ${{ matrix.compiler }}, ${{ matrix.build_type }})
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: ${{ matrix.install_deps }}
-
-      - name: Configure
-        run: >
-          cmake --preset decimator
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-
-      - name: Build decimator
-        run: cmake --build --preset decimator
-
-      - name: Test
-        run: ctest --preset decimator
-
-  # ── Airspy HF+ ZeroMQ build ───────────────────────────────────────
-  airspyhf-zeromq:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            name: Ubuntu
-            install_deps: |
-              set -euxo pipefail
-              sudo apt-get update
-              sudo apt-get install -y build-essential cmake libusb-1.0-0-dev libzmq3-dev pkg-config
-            ldconfig: sudo ldconfig
-          - os: macos-latest
-            name: macOS
-            install_deps: brew install libusb zeromq pkg-config
-            ldconfig: "true"
-
-    name: airspyhf-zeromq (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: ${{ matrix.install_deps }}
-
-      - name: Install system libairspyhf
-        run: |
-          cmake -S airspyhf_zeromq/libairspyhf -B build-lib -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-lib --parallel
-          sudo cmake --install build-lib
-          ${{ matrix.ldconfig }}
-
-      - name: Configure
-        run: cmake --preset airspyhf-zeromq
+        run: cmake --preset ${{ matrix.preset }}
 
       - name: Build
-        run: cmake --build --preset airspyhf-zeromq
-
-  # ── Wire-format header tests ───────────────────────────────────────
-  wireformat-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-latest]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure
-        run: cmake --preset wireformat-tests
-
-      - name: Build
-        run: cmake --build --preset wireformat-tests
+        run: cmake --build --preset ${{ matrix.preset }}
 
       - name: Test
-        run: ctest --preset wireformat-tests
+        if: matrix.preset == 'debug'
+        run: ctest --preset debug
 
   # ── Pulse detector validation ──────────────────────────────────────
   detector:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,67 @@ include(CTest)
 # ── CPM package manager ──────────────────────────────────────────────
 include(cmake/CPM.cmake)
 
-# ── Options to selectively build components ──────────────────────────
-option(BUILD_CONTROLLER     "Build the MAVLink tag controller"       ON)
-option(BUILD_DECIMATOR      "Build the ZeroMQ→UDP decimator"        ON)
-option(BUILD_AIRSPYHF_ZMQ   "Build the Airspy HF+ ZeroMQ receiver" ON)
+# ── Build dependency preflight (all components are always built) ─────
+set(Boost_USE_MULTITHREADED ON)
+find_package(Boost QUIET)
+if(NOT Boost_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: Boost\n"
+        "Install development package(s), e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install libboost-all-dev\n"
+        "  macOS (Homebrew): brew install boost"
+    )
+endif()
+
+find_package(Threads QUIET)
+if(NOT Threads_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: POSIX threads (pthreads)\n"
+        "This is normally provided by libc; ensure a C toolchain is installed, e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install build-essential"
+    )
+endif()
+
+find_package(PkgConfig QUIET)
+if(NOT PKG_CONFIG_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: pkg-config\n"
+        "Install it, e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install pkg-config\n"
+        "  macOS (Homebrew): brew install pkg-config"
+    )
+endif()
+
+pkg_check_modules(TOPLEVEL_ZMQ QUIET libzmq)
+if(NOT TOPLEVEL_ZMQ_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: libzmq\n"
+        "Install development package(s), e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install libzmq3-dev\n"
+        "  macOS (Homebrew): brew install zeromq"
+    )
+endif()
+
+pkg_check_modules(TOPLEVEL_LIBUSB QUIET libusb-1.0)
+if(NOT TOPLEVEL_LIBUSB_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: libusb-1.0\n"
+        "Install development package(s), e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install libusb-1.0-0-dev\n"
+        "  macOS (Homebrew): brew install libusb"
+    )
+endif()
+
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/airspyhf_zeromq/cmake/modules ${CMAKE_MODULE_PATH})
+find_package(LIBAIRSPYHF QUIET)
+if(NOT LIBAIRSPYHF_FOUND)
+    message(FATAL_ERROR
+        "Missing dependency: libairspyhf\n"
+        "Install development package(s), e.g.:\n"
+        "  Ubuntu/Debian: sudo apt install libairspyhf-dev\n"
+        "  macOS (Homebrew): brew install airspyhf"
+    )
+endif()
 
 # ── MAVLink C headers (fetched via CPM) ──────────────────────────────
 CPMAddPackage(
@@ -51,14 +108,6 @@ if(BUILD_TESTING)
 endif()
 
 # ── Components ───────────────────────────────────────────────────────
-if(BUILD_CONTROLLER)
-    add_subdirectory(controller)
-endif()
-
-if(BUILD_DECIMATOR)
-    add_subdirectory(decimator)
-endif()
-
-if(BUILD_AIRSPYHF_ZMQ)
-    add_subdirectory(airspyhf_zeromq)
-endif()
+add_subdirectory(controller)
+add_subdirectory(decimator)
+add_subdirectory(airspyhf_zeromq)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,47 +30,6 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
-        },
-        {
-            "name": "controller",
-            "displayName": "Controller only",
-            "inherits": "debug",
-            "cacheVariables": {
-                "BUILD_CONTROLLER": "ON",
-                "BUILD_DECIMATOR": "OFF",
-                "BUILD_AIRSPYHF_ZMQ": "OFF"
-            }
-        },
-        {
-            "name": "decimator",
-            "displayName": "Decimator only",
-            "inherits": "debug",
-            "cacheVariables": {
-                "BUILD_CONTROLLER": "OFF",
-                "BUILD_DECIMATOR": "ON",
-                "BUILD_AIRSPYHF_ZMQ": "OFF"
-            }
-        },
-        {
-            "name": "airspyhf-zeromq",
-            "displayName": "Airspy HF+ ZeroMQ only",
-            "inherits": "relwithdebinfo",
-            "cacheVariables": {
-                "BUILD_CONTROLLER": "OFF",
-                "BUILD_DECIMATOR": "OFF",
-                "BUILD_AIRSPYHF_ZMQ": "ON"
-            }
-        },
-        {
-            "name": "wireformat-tests",
-            "displayName": "Wire-format tests only",
-            "inherits": "debug",
-            "cacheVariables": {
-                "BUILD_CONTROLLER": "OFF",
-                "BUILD_DECIMATOR": "OFF",
-                "BUILD_AIRSPYHF_ZMQ": "OFF",
-                "BUILD_TESTING": "ON"
-            }
         }
     ],
     "buildPresets": [
@@ -88,54 +47,12 @@
             "name": "relwithdebinfo",
             "configurePreset": "relwithdebinfo",
             "jobs": 0
-        },
-        {
-            "name": "controller",
-            "configurePreset": "controller",
-            "targets": ["MavlinkTagController2"],
-            "jobs": 0
-        },
-        {
-            "name": "decimator",
-            "configurePreset": "decimator",
-            "targets": ["airspyhf_decimator", "airspyhf_decimator_tests"],
-            "jobs": 0
-        },
-        {
-            "name": "airspyhf-zeromq",
-            "configurePreset": "airspyhf-zeromq",
-            "targets": ["airspyhf_zeromq_rx"],
-            "jobs": 0
-        },
-        {
-            "name": "wireformat-tests",
-            "configurePreset": "wireformat-tests",
-            "jobs": 0
         }
     ],
     "testPresets": [
         {
             "name": "debug",
             "configurePreset": "debug",
-            "output": {
-                "outputOnFailure": true
-            }
-        },
-        {
-            "name": "decimator",
-            "configurePreset": "decimator",
-            "output": {
-                "outputOnFailure": true
-            },
-            "filter": {
-                "include": {
-                    "name": "airspyhf_decimator_tests"
-                }
-            }
-        },
-        {
-            "name": "wireformat-tests",
-            "configurePreset": "wireformat-tests",
             "output": {
                 "outputOnFailure": true
             }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ cmake/                         Build utilities
 setup/                         Raspberry Pi setup and boot scripts
 ```
 
+## Build prerequisites
+
+Top-level CMake now checks these at configure time:
+
+- Boost
+- Threads (pthreads)
+- pkg-config
+- libzmq
+- libusb-1.0
+- libairspyhf (system-installed)
+
+Install on Ubuntu/Debian:
+
+```bash
+sudo apt install build-essential cmake pkg-config libboost-all-dev libzmq3-dev libusb-1.0-0-dev libairspyhf-dev
+```
+
+Install on macOS (Homebrew):
+
+```bash
+brew install cmake pkg-config boost zeromq libusb airspyhf
+```
+
 ## Quick start
 
 ### Build controller + decimator (default)
@@ -66,7 +89,7 @@ make
 ```bash
 make controller
 make decimator
-make airspyhf_zeromq   # requires libairspyhf + libusb on the system
+make airspyhf_zeromq
 ```
 
 ### Run tests
@@ -79,9 +102,6 @@ make test
 
 ```bash
 cmake -S . -B build \
-    -DBUILD_CONTROLLER=ON \
-    -DBUILD_DECIMATOR=ON \
-    -DBUILD_AIRSPYHF_ZMQ=OFF \
     -DBUILD_TESTING=ON
 cmake --build build --parallel
 ctest --test-dir build --output-on-failure
@@ -91,9 +111,6 @@ ctest --test-dir build --output-on-failure
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `BUILD_CONTROLLER` | `ON` | Build the MAVLink tag controller |
-| `BUILD_DECIMATOR` | `ON` | Build the ZeroMQ→UDP decimator |
-| `BUILD_AIRSPYHF_ZMQ` | `OFF` | Build the Airspy HF+ ZeroMQ receiver (needs system libairspyhf + libusb) |
 | `BUILD_TESTING` | `OFF` | Build and register tests |
 
 ## Component details
@@ -116,7 +133,7 @@ See [decimator usage details](#decimator-usage) below.
 
 Streams Airspy HF+ SDR IQ data over ZeroMQ PUB. Each message contains a fixed 40-byte header followed by interleaved float32 IQ payload.
 
-**Dependencies:** libairspyhf, libusb-1.0, libzmq
+**Dependencies:** system `libairspyhf`, libusb-1.0, libzmq
 
 ## Decimator usage
 

--- a/airspyhf_zeromq/CMakeLists.txt
+++ b/airspyhf_zeromq/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-message(STATUS "Using system libairspyhf")
 add_subdirectory(tools)
 
 if(BUILD_TESTING)

--- a/airspyhf_zeromq/cmake/modules/FindLIBAIRSPY.cmake
+++ b/airspyhf_zeromq/cmake/modules/FindLIBAIRSPY.cmake
@@ -20,15 +20,20 @@ else (LIBAIRSPYHF_INCLUDE_DIR AND LIBAIRSPYHF_LIBRARIES)
     # in the FIND_PATH() and FIND_LIBRARY() calls
     find_package(PkgConfig)
     pkg_check_modules(PC_LIBAIRSPYHF QUIET libairspyhf)
+    if(NOT PC_LIBAIRSPYHF_FOUND)
+      pkg_check_modules(PC_LIBAIRSPYHF QUIET airspyhf)
+    endif()
   ENDIF(NOT WIN32)
 
   FIND_PATH(LIBAIRSPYHF_INCLUDE_DIR
     NAMES airspyhf.h
     HINTS $ENV{LIBAIRSPYHF_DIR}/include ${PC_LIBAIRSPYHF_INCLUDEDIR}
-    PATHS /usr/local/include/libairspyhf /usr/include/libairspyhf /usr/local/include /usr/include
+    PATHS /usr/local/include/libairspyhf /usr/include/libairspyhf /usr/local/include /usr/include /usr/include/airspyhf /usr/local/include/airspyhf
     ${CMAKE_SOURCE_DIR}/../libairspyhf/src
     /opt/local/include/libairspyhf
+    /opt/local/include/airspyhf
     /opt/homebrew/include/libairspyhf
+    /opt/homebrew/include/airspyhf
     ${LIBAIRSPYHF_INCLUDE_DIR}
   )
 
@@ -37,7 +42,7 @@ else (LIBAIRSPYHF_INCLUDE_DIR AND LIBAIRSPYHF_LIBRARIES)
   FIND_LIBRARY(LIBAIRSPYHF_LIBRARIES
     NAMES ${libairspyhf_library_names}
     HINTS $ENV{LIBAIRSPYHF_DIR}/lib ${PC_LIBAIRSPYHF_LIBDIR}
-    PATHS /usr/local/lib /usr/lib /opt/local/lib /opt/homebrew/lib ${PC_LIBAIRSPYHF_LIBDIR} ${PC_LIBAIRSPYHF_LIBRARY_DIRS} ${CMAKE_SOURCE_DIR}/../libairspyhf/src
+    PATHS /usr/local/lib /usr/lib /usr/lib64 /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /opt/local/lib /opt/homebrew/lib ${PC_LIBAIRSPYHF_LIBDIR} ${PC_LIBAIRSPYHF_LIBRARY_DIRS} ${CMAKE_SOURCE_DIR}/../libairspyhf/src
   )
 
   if(LIBAIRSPYHF_INCLUDE_DIR)

--- a/airspyhf_zeromq/cmake/modules/FindUSB1.cmake
+++ b/airspyhf_zeromq/cmake/modules/FindUSB1.cmake
@@ -1,9 +1,12 @@
-# - Try to find the freetype library
+# - Try to find the libusb-1.0 (USB1) library
 # Once done this defines
 #
-#  LIBUSB_FOUND - system has libusb
-#  LIBUSB_INCLUDE_DIR - the libusb include directory
-#  LIBUSB_LIBRARIES - Link these to use libusb
+#  USB1_FOUND - system has libusb-1.0
+#  USB1_INCLUDE_DIR - the libusb include directory
+#  USB1_LIBRARIES - Link these to use libusb
+#
+# Compatibility aliases are also provided:
+#  LIBUSB_FOUND, LIBUSB_INCLUDE_DIR, LIBUSB_LIBRARIES
 
 # Copyright (c) 2006, 2008  Laurent Montel, <montel@kde.org>
 #
@@ -11,27 +14,31 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 
-if (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+if (USB1_INCLUDE_DIR AND USB1_LIBRARIES)
 
   # in cache already
-  set(LIBUSB_FOUND TRUE)
+  set(USB1_FOUND TRUE)
 
-else (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+else (USB1_INCLUDE_DIR AND USB1_LIBRARIES)
 
   find_package(PkgConfig)
   if(PKG_CONFIG_FOUND)
     pkg_check_modules(PC_LIBUSB libusb-1.0)
   endif(PKG_CONFIG_FOUND)
 
-  FIND_PATH(LIBUSB_INCLUDE_DIR libusb.h
+  FIND_PATH(USB1_INCLUDE_DIR libusb.h
     PATHS ${PC_LIBUSB_INCLUDEDIR} ${PC_LIBUSB_INCLUDE_DIRS})
 
-  FIND_LIBRARY(LIBUSB_LIBRARIES NAMES usb-1.0
+  FIND_LIBRARY(USB1_LIBRARIES NAMES usb-1.0
     PATHS ${PC_LIBUSB_LIBDIR} ${PC_LIBUSB_LIBRARY_DIRS})
 
   include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBUSB DEFAULT_MSG LIBUSB_LIBRARIES LIBUSB_INCLUDE_DIR)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(USB1 DEFAULT_MSG USB1_LIBRARIES USB1_INCLUDE_DIR)
 
-  MARK_AS_ADVANCED(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARIES)
+  MARK_AS_ADVANCED(USB1_INCLUDE_DIR USB1_LIBRARIES)
 
-endif (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+endif (USB1_INCLUDE_DIR AND USB1_LIBRARIES)
+
+set(LIBUSB_FOUND ${USB1_FOUND})
+set(LIBUSB_INCLUDE_DIR ${USB1_INCLUDE_DIR})
+set(LIBUSB_LIBRARIES ${USB1_LIBRARIES})

--- a/airspyhf_zeromq/tools/CMakeLists.txt
+++ b/airspyhf_zeromq/tools/CMakeLists.txt
@@ -39,12 +39,8 @@ else()
 add_definitions(-Wall)
 endif()
 
-if(NOT libairspyhf_SOURCE_DIR)
 find_package(LIBAIRSPYHF REQUIRED)
 include_directories(${LIBAIRSPYHF_INCLUDE_DIR})
-else()
-include_directories(${libairspyhf_SOURCE_DIR}/src)
-endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PC_ZMQ REQUIRED IMPORTED_TARGET libzmq)

--- a/airspyhf_zeromq/tools/src/CMakeLists.txt
+++ b/airspyhf_zeromq/tools/src/CMakeLists.txt
@@ -34,18 +34,21 @@ add_executable(airspyhf_zeromq_rx airspyhf_rx.c)
 target_include_directories(airspyhf_zeromq_rx PRIVATE
     ${CMAKE_SOURCE_DIR}/shared
 )
+# Third-party C source — suppress warnings that conflict with top-level -Werror
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(airspyhf_zeromq_rx PRIVATE
+        -Wno-error
+        -Wno-unused-parameter
+        -Wno-sign-compare
+    )
+endif()
 install(TARGETS airspyhf_zeromq_rx RUNTIME DESTINATION ${INSTALL_DEFAULT_BINDIR})
 
 set_target_properties(airspyhf_zeromq_rx PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE
 )
 
-if(NOT libairspyhf_SOURCE_DIR)
-include_directories(${LIBAIRSPYHF_INCLUDE_DIR})
 LIST(APPEND TOOLS_LINK_LIBS ${LIBAIRSPYHF_LIBRARIES})
-else()
-LIST(APPEND TOOLS_LINK_LIBS airspyhf)
-endif()
 
 if(MSVC)
 LIST(APPEND TOOLS_LINK_LIBS libgetopt_static)

--- a/setup/full_setup.sh
+++ b/setup/full_setup.sh
@@ -4,7 +4,7 @@ set -e
 # wget https://raw.githubusercontent.com/DonLakeFlyer/MavlinkTagController2/main/setup/full_setup.sh
 
 echo "*** Install tools"
-sudo apt install build-essential git cmake libboost-all-dev airspy libfftw3-dev libzmq3-dev libusb-1.0-0-dev pkg-config -y
+sudo apt install build-essential git cmake libboost-all-dev libairspyhf-dev libfftw3-dev libzmq3-dev libusb-1.0-0-dev pkg-config -y
 git config --global pull.rebase false
 
 echo "*** Create repos directory"
@@ -22,14 +22,8 @@ fi
 cd ~/repos/MavlinkTagController2
 git pull origin main
 
-echo "*** Build and install libairspyhf"
-cmake -S airspyhf_zeromq/libairspyhf -B build-lib -DCMAKE_BUILD_TYPE=Release
-cmake --build build-lib --parallel
-sudo cmake --install build-lib
-sudo ldconfig
-
 echo "*** Build all components"
-cmake -Bbuild -H. -DCMAKE_BUILD_TYPE=Debug -DBUILD_CONTROLLER=ON -DBUILD_DECIMATOR=ON -DBUILD_AIRSPYHF_ZMQ=ON
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j4
 
 echo "*** Install airspyhf_zeromq"


### PR DESCRIPTION
## Summary

Remove all component selection options and require system-installed libairspyhf. Everything now builds unconditionally.

## Changes

- **Remove `BUILD_CONTROLLER`, `BUILD_DECIMATOR`, `BUILD_AIRSPYHF_ZMQ` options** — all three components build every time.
- **Remove component-specific CMake presets** — keep only debug / release / relwithdebinfo.
- **Add dependency preflight checks** at configure time with actionable install hints for Boost, Threads, pkg-config, libzmq, libusb-1.0, and libairspyhf.
- **Require system-installed libairspyhf** (`sudo apt install libairspyhf-dev` / `brew install airspyhf`) instead of building the vendored copy as a subdirectory. `airspyhf_zeromq_rx` links exclusively against the system library.
- **Scope warning suppression to `airspyhf_zeromq_rx` target only** — `-Wno-error`, `-Wno-unused-parameter`, `-Wno-sign-compare` no longer leak to tests or other tool code.
- **Harden `FindUSB1.cmake`** — rename internal variables to `USB1_*` to match `find_package(USB1)` convention; add backward-compatible `LIBUSB_*` aliases.
- **Expand `FindLIBAIRSPY.cmake`** with pkg-config fallback and Linux multiarch / Homebrew library search paths.
- **Update README** — add build prerequisites section with `apt` and `brew` install commands.
- **Update `setup/full_setup.sh`** — install `libairspyhf-dev` via apt; remove standalone build-from-source block.

## Testing

- Clean configure + build succeeds on Linux aarch64 (GCC 13.3.0).
- `ldd` confirms `airspyhf_zeromq_rx` links `/lib/aarch64-linux-gnu/libairspyhf.so.1` (system package).
- All CTest tests pass (2 passed, 2 hardware-dependent skipped).