### PR TITLE
Add --simulator mode to controller pipeline

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,21 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
+        },
+        {
+            "name": "controller",
+            "displayName": "Controller (Debug)",
+            "inherits": "debug"
+        },
+        {
+            "name": "decimator",
+            "displayName": "Decimator (Debug)",
+            "inherits": "debug"
+        },
+        {
+            "name": "airspyhf-zeromq",
+            "displayName": "AirSpy HF ZeroMQ (Debug)",
+            "inherits": "debug"
         }
     ],
     "buildPresets": [
@@ -47,6 +62,24 @@
             "name": "relwithdebinfo",
             "configurePreset": "relwithdebinfo",
             "jobs": 0
+        },
+        {
+            "name": "controller",
+            "configurePreset": "controller",
+            "jobs": 0,
+            "targets": ["MavlinkTagController2"]
+        },
+        {
+            "name": "decimator",
+            "configurePreset": "decimator",
+            "jobs": 0,
+            "targets": ["airspyhf_decimator"]
+        },
+        {
+            "name": "airspyhf-zeromq",
+            "configurePreset": "airspyhf-zeromq",
+            "jobs": 0,
+            "targets": ["airspyhf_zeromq_rx"]
         }
     ],
     "testPresets": [

--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -14,13 +14,14 @@ class LogFileManager;
 
 class CommandHandler {
 public:
-    explicit CommandHandler(MavlinkSystem* mavlink);
+    explicit CommandHandler(MavlinkSystem* mavlink, bool simulatorMode = false, const std::string& simulatorPreset = "strong");
 
 private:
     enum class AirSpyDeviceType {
         NONE,
         MINI,
-        HF
+        HF,
+        SIMULATOR
     };
 
 
@@ -42,6 +43,8 @@ private:
     std::string _tunnelCommandIdToString    (uint32_t command);
     std::string _tunnelCommandResultToString(uint32_t result);
 
+    std::string _simulatorCommand(uint32_t radioCenterFrequencyHz) const;
+
     MavlinkSystem*                  _mavlink                = nullptr;
     TagDatabase                     _tagDatabase;
     bool                            _receivingTags          = false;
@@ -50,6 +53,8 @@ private:
     bp::pipe*                       _airspyPipe             = nullptr;
     std::string                     _airspyPath;
     int                            _rawCaptureCount         = 0;
+    bool                            _simulatorMode          = false;
+    std::string                     _simulatorPreset;
 
     static constexpr int kAirSpyHfFrequencyOffsetHz = 10000; // 10 kHz - takes into account 768 ksps incoming and 3840 Hz outgoing
 };

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -115,6 +115,37 @@ source .venv/bin/activate
 python simulator/iq_simulator.py --preset strong -P 5555
 ```
 
+## Controller-integrated mode
+
+The controller binary supports a `--simulator` flag that replaces the SDR
+hardware with `iq_simulator.py` inside the managed pipeline. No separate
+script is needed — the controller spawns the simulator, decimator, and
+detectors automatically when detection is started via the MAVLink tunnel.
+
+```bash
+# Build the controller
+make controller
+
+# Start with default preset ("strong")
+./build/controller/MavlinkTagController2 --simulator
+
+# Start with a specific preset
+./build/controller/MavlinkTagController2 --simulator weak
+
+# Combine with a connection URL
+./build/controller/MavlinkTagController2 --simulator two-tags serial:///dev/ttyACM0:115200
+```
+
+In this mode:
+- SDR hardware detection is bypassed
+- `iq_simulator.py` publishes IQ on ZMQ PUB port 5555
+- The decimator uses `--shift-khz 0` (no DC-spur offset)
+- `uavrt_detection` processes run unchanged
+- Tag parameters from the MAVLink tag database are mapped to simulator
+  `--freq-offset-hz`, `--tp`, and `--tip` arguments
+- If no tags are configured when detection starts, the selected preset is used
+- The Python venv at `$REPO/.venv` is preferred; falls back to system `python3`
+
 ## Signal model
 
 - **Noise**: Complex Gaussian white noise at configurable power level


### PR DESCRIPTION
Replace SDR hardware with `iq_simulator.py` in the controller-managed pipeline when the `--simulator [preset]` CLI flag is passed.

## Controller changes
- `main.cpp`: parse `--simulator [preset]` flag (default: `strong`)
- `CommandHandler`: add `SIMULATOR` device type that bypasses SDR hardware detection, spawns `iq_simulator.py` as the IQ source on ZMQ PUB :5555, and runs the decimator with `--shift-khz 0` (no DC-spur offset needed)
- Tag database entries are mapped to simulator `--freq-offset-hz`, `--tp`, and `--tip` arguments; falls back to the selected preset when no tags are configured
- Raw capture returns a clear error in simulator mode
- Prefers the repo venv python; falls back to system `python3`

## Build system
- Add `controller`, `decimator`, and `airspyhf-zeromq` CMake presets so the Makefile per-component targets (`make controller`, etc.) work correctly

## Documentation
- `README.md`: document `--simulator` usage, simulator architecture diagram, CMake presets table, repo layout for `simulator/` and `detector/`
- `simulator/README.md`: add controller-integrated mode section

## Usage
```bash
# Default preset (strong), default SITL connection
./build/controller/MavlinkTagController2 --simulator

# Specific preset
./build/controller/MavlinkTagController2 --simulator weak

# With a connection URL
./build/controller/MavlinkTagController2 --simulator two-tags serial:///dev/ttyACM0:115200
```