### PR TITLE
Add controller→simulator ZMQ telemetry and directional antenna SNR model

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 
 set(Boost_USE_MULTITHREADED ON)
 find_package(Boost REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CONTROLLER_ZMQ REQUIRED IMPORTED_TARGET libzmq)
 
 add_executable(MavlinkTagController2
     main.cpp
@@ -26,6 +28,7 @@ add_executable(MavlinkTagController2
     LogFileManager.cpp LogFileManager.h
     MavlinkFtpServer.cpp MavlinkFtpServer.h
     PulseHandler.cpp PulseHandler.h
+    SimulatorTelemetryPublisher.cpp SimulatorTelemetryPublisher.h
 )
 
 target_include_directories(MavlinkTagController2
@@ -39,4 +42,5 @@ target_link_libraries(MavlinkTagController2
     PRIVATE
     ${Boost_LIBRARIES}
     mavlink
+    PkgConfig::CONTROLLER_ZMQ
 )

--- a/controller/SimulatorTelemetryPublisher.cpp
+++ b/controller/SimulatorTelemetryPublisher.cpp
@@ -1,0 +1,120 @@
+#include "SimulatorTelemetryPublisher.h"
+
+#include "MavlinkSystem.h"
+#include "Telemetry.h"
+#include "log.h"
+#include "timeHelpers.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+
+#include <zmq.h>
+
+SimulatorTelemetryPublisher::SimulatorTelemetryPublisher(MavlinkSystem* mavlink, const std::string& endpoint, int publishPeriodMs)
+	: _mavlink(mavlink)
+	, _endpoint(endpoint)
+	, _publishPeriodMs(publishPeriodMs)
+	, _zmqContext(nullptr)
+	, _zmqPub(nullptr)
+	, _running(false)
+{
+}
+
+SimulatorTelemetryPublisher::~SimulatorTelemetryPublisher()
+{
+	stop();
+}
+
+bool SimulatorTelemetryPublisher::start()
+{
+	if (_running) {
+		return true;
+	}
+
+	_zmqContext = zmq_ctx_new();
+	if (_zmqContext == nullptr) {
+		logError() << "SimulatorTelemetryPublisher: zmq_ctx_new failed";
+		return false;
+	}
+
+	_zmqPub = zmq_socket(_zmqContext, ZMQ_PUB);
+	if (_zmqPub == nullptr) {
+		logError() << "SimulatorTelemetryPublisher: zmq_socket failed";
+		zmq_ctx_term(_zmqContext);
+		_zmqContext = nullptr;
+		return false;
+	}
+
+	int sndHwm = 8;
+	zmq_setsockopt(_zmqPub, ZMQ_SNDHWM, &sndHwm, sizeof(sndHwm));
+
+	if (zmq_bind(_zmqPub, _endpoint.c_str()) != 0) {
+		logError() << "SimulatorTelemetryPublisher: zmq_bind failed for" << _endpoint << "error:" << zmq_strerror(zmq_errno());
+		zmq_close(_zmqPub);
+		_zmqPub = nullptr;
+		zmq_ctx_term(_zmqContext);
+		_zmqContext = nullptr;
+		return false;
+	}
+
+	_running = true;
+	_thread = std::make_unique<std::thread>(&SimulatorTelemetryPublisher::_run, this);
+
+	logInfo() << "SimulatorTelemetryPublisher: publishing vehicle telemetry on" << _endpoint;
+	return true;
+}
+
+void SimulatorTelemetryPublisher::stop()
+{
+	if (!_running) {
+		return;
+	}
+
+	_running = false;
+
+	if (_thread && _thread->joinable()) {
+		_thread->join();
+	}
+	_thread.reset();
+
+	if (_zmqPub != nullptr) {
+		zmq_close(_zmqPub);
+		_zmqPub = nullptr;
+	}
+
+	if (_zmqContext != nullptr) {
+		zmq_ctx_term(_zmqContext);
+		_zmqContext = nullptr;
+	}
+}
+
+void SimulatorTelemetryPublisher::_run()
+{
+	while (_running) {
+		auto position = _mavlink->telemetry().lastPosition();
+		auto attitude = _mavlink->telemetry().lastAttitudeEuler();
+
+		if (position.has_value() && attitude.has_value()) {
+			char payload[320] = {};
+			double timestampSec = secondsSinceEpoch();
+			std::snprintf(
+				payload,
+				sizeof(payload),
+				"vehicle_pose {\"t\":%.6f,\"lat_deg\":%.8f,\"lon_deg\":%.8f,\"alt_m\":%.3f,\"yaw_deg\":%.3f}",
+				timestampSec,
+				position->latitude,
+				position->longitude,
+				position->relativeAltitude,
+				attitude->yawDegrees);
+
+			const int rc = zmq_send(_zmqPub, payload, std::strlen(payload), ZMQ_DONTWAIT);
+			if (rc < 0 && zmq_errno() != EAGAIN) {
+				logWarn() << "SimulatorTelemetryPublisher: zmq_send failed:" << zmq_strerror(zmq_errno());
+			}
+		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(_publishPeriodMs));
+	}
+}

--- a/controller/SimulatorTelemetryPublisher.h
+++ b/controller/SimulatorTelemetryPublisher.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+class MavlinkSystem;
+
+class SimulatorTelemetryPublisher
+{
+public:
+	SimulatorTelemetryPublisher(MavlinkSystem* mavlink, const std::string& endpoint, int publishPeriodMs);
+	~SimulatorTelemetryPublisher();
+
+	bool start();
+	void stop();
+
+private:
+	void _run();
+
+	MavlinkSystem* _mavlink;
+	std::string _endpoint;
+	int _publishPeriodMs;
+	void* _zmqContext;
+	void* _zmqPub;
+	std::unique_ptr<std::thread> _thread;
+	std::atomic_bool _running;
+};


### PR DESCRIPTION
Adds controller-to-simulator ZeroMQ vehicle telemetry plus directional antenna SNR modeling in simulator/iq_simulator.py. Controller publishes vehicle_pose on tcp://127.0.0.1:6001 by default (overridable via --sim-telemetry-endpoint), simulator subscribes by default at same endpoint, sets transmitter 1 km north of first vehicle pose, and applies heading-relative gain + distance loss for tag 0. Controller build validated successfully.