### PR TITLE
Add Python detection mode support

### DIFF
--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -36,6 +36,7 @@ private:
     bool _handleCleanLogs       (void);
     void _handleTunnelMessage   (const mavlink_message_t& message);
     void _startDetector         (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel);
+    void _startPythonDetector   (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode);
     AirSpyDeviceType _connectedAirSpyType(std::string* errorMessage = nullptr);
     std::string _sdrPathStatusText(AirSpyDeviceType deviceType, double frequencyMhz) const;
     std::string _checkForAirSpy  (void);


### PR DESCRIPTION
## Summary

Adds support for a new Python-based pulse detector mode, selectable via `detection_mode` in `StartDetectionInfo_t`.

## Changes

### Protocol (tunnel-protocol submodule)
- Updates submodule pointer to include `DETECTION_MODE_UAVRT` (0) and `DETECTION_MODE_PYTHON` (1) constants
- Adds `uint32_t detection_mode` field to `StartDetectionInfo_t`

### Controller
- **CommandHandler.h/cpp**: Adds `_startPythonDetector()` which spawns `pulse_detector.py` with the correct parameters (`--tp`, `--tip`, `--fs`, `--port`, `--tag-id`, `--freq`, `--pulse-port`, `--center-freq`)
- Branches on `detection_mode` in the detector launch loop — `DETECTION_MODE_PYTHON` launches the Python detector, default launches uavrt_detection
- Supports both primary and secondary channels (moving/resting pulse rates)
- Uses venv Python if available, falls back to system `python3`

### Python Detector (pulse_detector.py)
- Adds `send_pulse_udp()` — packs detected pulses as 12-double UDPPulseInfo_T packets and sends to port 50000
- Adds `send_heartbeat_udp()` — sends periodic heartbeats (`frequency_hz=0`) every ~1 second so the controller knows the detector is alive
- Pulses sent with `confirmed_status=1`
- New CLI arguments: `--tag-id`, `--freq`, `--pulse-port`

## Testing
- Build passes (CMake/Ninja, C++20, `-Werror`)
- Python syntax check passes