### PR TITLE
setup: activate .venv in crontab controller launcher

### DIFF
--- a/setup/crontab-start-controller.sh
+++ b/setup/crontab-start-controller.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+set -euo pipefail
+
+REPO_DIR="/home/pi/repos/MavlinkTagController2"
+VENV_ACTIVATE="$REPO_DIR/.venv/bin/activate"
+
+if [ ! -f "$VENV_ACTIVATE" ]; then
+    echo "Virtual environment not found at $VENV_ACTIVATE" >&2
+    echo "Run $REPO_DIR/setup_venv.sh first." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_ACTIVATE"
+
 if [ -f /home/pi/MavlinkTagController.log ]; then
     mv -f /home/pi/MavlinkTagController.log /home/pi/MavlinkTagController.log.save
     tail -n 500 /home/pi/MavlinkTagController.log.save >> /home/pi/MavlinkTagController.log


### PR DESCRIPTION
## Summary
- activate the repo virtual environment in the cron startup script
- fail fast with a clear message if the venv is missing
- keep existing log rotation and controller launch behavior

## Testing
- not run (shell script change only)