### PR TITLE
Fix PR #73 code review issues

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -157,14 +157,14 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
     std::string venvPython  = formatString("%s/.venv/bin/python3", repoDir.c_str());
     std::string pythonCmd   = (access(venvPython.c_str(), X_OK) == 0) ? venvPython : std::string("python3");
 
-    std::string commandStr  = formatString("%s -u %s/detector/pulse_detector.py"
+    std::string commandStr  = formatString("\"%s\" -u \"%s/detector/pulse_detector.py\""
                                            " --tp %f --tip %f --fs %d --port %d"
-                                           " --tag-id %d --freq %u --pulse-port 50000"
+                                           " --tag-id %d --freq %u --pulse-port %d"
                                            " --center-freq %f",
                                 pythonCmd.c_str(),
                                 repoDir.c_str(),
                                 tp, tip, sampleRate, portData,
-                                tagId, tagInfo.frequency_hz,
+                                tagId, tagInfo.frequency_hz, kPulseUdpPort,
                                 centerFreqMhz);
 
     std::string root    = formatString("py_detector_%d", tagId);
@@ -172,9 +172,10 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
 
     logInfo() << "Starting Python pulse detector:" << commandStr;
 
+    std::string procName = formatString("pulse_detector_%d", tagId);
     MonitoredProcess* detectorProc = new MonitoredProcess(
                                                 _mavlink,
-                                                "pulse_detector",
+                                                procName.c_str(),
                                                 commandStr.c_str(),
                                                 logPath.c_str(),
                                                 MonitoredProcess::NoPipe,

--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -16,6 +16,8 @@ class CommandHandler {
 public:
     explicit CommandHandler(MavlinkSystem* mavlink, bool simulatorMode = false, const std::string& simulatorPreset = "strong");
 
+    static constexpr int kPulseUdpPort = 50000; // UDP port for pulse/heartbeat reports from detectors
+
 private:
     enum class AirSpyDeviceType {
         NONE,

--- a/controller/main.cpp
+++ b/controller/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
     auto ftpServer 			= MavlinkFtpServer { mavlink };
     auto telemetryCache     = new TelemetryCache(mavlink);
 	auto pulseHandler 		= new PulseHandler(mavlink, telemetryCache);
-    auto udpPulseReceiver   = UDPPulseReceiver { std::string("127.0.0.1"), 50000, pulseHandler };
+    auto udpPulseReceiver   = UDPPulseReceiver { std::string("127.0.0.1"), CommandHandler::kPulseUdpPort, pulseHandler };
 
 	globalMavlinkSystem		= mavlink;
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -74,7 +74,10 @@ def send_pulse_udp(pulse_sock, dest_addr, tag_id, frequency_hz,
                          float(detection_status),
                          float(confirmed_status),
                          noise_psd)
-    pulse_sock.sendto(packet, dest_addr)
+    try:
+        pulse_sock.sendto(packet, dest_addr)
+    except OSError as e:
+        print(f'Warning: pulse send failed: {e}', file=sys.stderr, flush=True)
 
 
 def send_heartbeat_udp(pulse_sock, dest_addr, tag_id):
@@ -635,6 +638,11 @@ def main():
             try:
                 data = sock.recv(65536)
             except socket.timeout:
+                # Send heartbeat even while waiting for data so the controller
+                # knows we're alive during long buffering periods or stream stalls
+                if pulse_sock is not None and (time.monotonic() - last_heartbeat_time) >= heartbeat_interval:
+                    send_heartbeat_udp(pulse_sock, pulse_dest, args.tag_id)
+                    last_heartbeat_time = time.monotonic()
                 continue
             if len(data) < 16:
                 continue


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot code review comments from PR #73 (Add Python detection mode support).

## Changes

### 1. Extract magic port constant
Port `50000` was hardcoded in both `CommandHandler.cpp` and `main.cpp`. Extracted to `CommandHandler::kPulseUdpPort` (public constexpr) so both sites reference a single source of truth.

### 2. Handle `sendto()` errors in pulse_detector.py
`sendto()` was unguarded — any `OSError` would crash the detector. Now wrapped in `try/except OSError` with a stderr warning so pulse reporting failures don't take down the detection pipeline.

### 3. Fix heartbeat timing
Heartbeats were only checked after a full segment was processed, meaning they could stall during long buffering periods or stream outages. Moved the heartbeat check into the `socket.timeout` handler in the recv loop so heartbeats fire even while waiting for data.

### 4. Shell-quote paths
Python executable and script paths were interpolated without quoting. Added double-quotes around `%s` substitutions in the `formatString` call to handle spaces in directory names.

### 5. Unique process names
All Python detector instances shared the name `"pulse_detector"`, making log correlation ambiguous. Changed to `"pulse_detector_<tagId>"` so each instance is identifiable.

## Testing

- C++ build passes (CMake/Ninja, `-Werror`)
- Python syntax check passes
- All existing tests pass