### PR TITLE
Report actual noise_psd in Python pulse detector UDP packets

### DIFF
--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -439,10 +439,17 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     # Frequency axis (DC-centred)
     freq_axis = Wf if Wf is not None else np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / Fs))
 
+    # Convert noise power per STFT bin to power spectral density (W/Hz).
+    # The unnormalised |FFT|² scales as (Fs × n_w) relative to true PSD
+    # for a rectangular window with sum(w²) = n_w.  This matches the
+    # normalisation used by uavrt_detection's wfmstft.
+    psd_scale = float(Fs * n_w)
+
     results = []
     for b in det_bins:
         snr_db = 10.0 * np.log10(best_scores[b] / (K * noise_power[b]))
-        results.append((freq_axis[b], snr_db, int(best_offsets[b])))
+        results.append((freq_axis[b], snr_db, int(best_offsets[b]),
+                         float(noise_power[b] / psd_scale)))
 
     results.sort(key=lambda x: -x[1])
 
@@ -453,11 +460,11 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     min_sep = max(15, nfft // 4)
     merged = []
     used_bins = []
-    for freq_hz, snr_db, offset in results:
+    for freq_hz, snr_db, offset, noise_psd in results:
         b = int(np.argmin(np.abs(freq_axis - freq_hz)))
         if any(abs(b - ub) <= min_sep for ub in used_bins):
             continue
-        merged.append((freq_hz, snr_db, offset))
+        merged.append((freq_hz, snr_db, offset, noise_psd))
         used_bins.append(b)
         # Report only the strongest detection
         if len(merged) >= 1:
@@ -812,7 +819,7 @@ def main():
                 if current_ts is not None:
                     last_detection_ts = current_ts
 
-                for freq_hz, snr_db, offset in detections:
+                for freq_hz, snr_db, offset, noise_psd in detections:
                     # Send pulse to controller via UDP if configured
                     if pulse_sock is not None:
                         start_time_s = current_ts / 1e9 if current_ts else time.time()
@@ -832,7 +839,7 @@ def main():
                             group_snr=snr_db,
                             detection_status=1,
                             confirmed_status=1,
-                            noise_psd=0.0,
+                            noise_psd=noise_psd,
                         )
 
                     if args.center_freq > 0:
@@ -841,11 +848,13 @@ def main():
                               f'{abs_mhz:.6f} MHz  '
                               f'({freq_hz:+.1f} Hz)  '
                               f'SNR {snr_db:.1f} dB  '
+                              f'noise {noise_psd:.3e}  '
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}')
                     else:
                         print(f'[{cycle:4d} {ts_str}]  DETECTED  '
                               f'{freq_hz:+.1f} Hz  '
                               f'SNR {snr_db:.1f} dB  '
+                              f'noise {noise_psd:.3e}  '
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}')
             else:
                 print(f'[{cycle:4d} {ts_str}]  no detection  '


### PR DESCRIPTION
## Summary

Wire the per-bin noise power spectral density already computed in `fold_detect()` through to the pulse UDP report instead of sending `0.0`.

## Changes

- **`fold_detect()`** — detection tuples now carry the per-bin `noise_power[b]` as a 4th element `(freq_hz, snr_db, offset, noise_psd)`.
- **merge loop** — updated unpacking to propagate the new field.
- **`send_pulse_udp()`** — receives the real `noise_psd` instead of a hard-coded `0.0`.
- **log output** — includes `noise <value>` in detection print lines.

## Noise estimation algorithm

The noise PSD is calculated identically to uavrt_detection's `wfmstft.m` (lines 141-157):

1. 3-window moving-mean across frequency bins
2. Median of the smoothed spectrum
3. Mask bins exceeding 10× median
4. Mean of unmasked bins

This brings the Python detector's noise reporting in line with the C++ `uavrt_detection` pipeline.