### PR TITLE
Report no-detection cycles to controller with detection_status=3

### DIFF
--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -12,11 +12,15 @@
 #include <unistd.h> // for close()
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 #include <iostream>
 #include <string.h>
 #include <cstddef>
 #include <chrono>
+
+// Detection status values (mirrors TunnelProtocol.h detection_status field)
+static constexpr uint8_t DETECTION_STATUS_NO_DETECTION = 3;
 
 using namespace TunnelProtocol;
 
@@ -45,7 +49,8 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
 
     if (pulseInfo.frequency_hz == 0) {
         logInfo() << "HEARTBEAT from Detector" << pulseInfo.tag_id;
-    } else if ((uint8_t)udpPulseInfo.detection_status == 3) {
+    } else if (std::isfinite(udpPulseInfo.detection_status)
+              && static_cast<uint8_t>(udpPulseInfo.detection_status) == DETECTION_STATUS_NO_DETECTION) {
         // No pulse detected this cycle — forward noise floor to GCS
         pulseInfo.detection_status  = 3;
         pulseInfo.confirmed_status  = 0;

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -52,7 +52,7 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
     } else if (std::isfinite(udpPulseInfo.detection_status)
               && static_cast<uint8_t>(udpPulseInfo.detection_status) == DETECTION_STATUS_NO_DETECTION) {
         // No pulse detected this cycle — forward noise floor to GCS
-        pulseInfo.detection_status  = 3;
+        pulseInfo.detection_status  = DETECTION_STATUS_NO_DETECTION;
         pulseInfo.confirmed_status  = 0;
         pulseInfo.noise_psd         = udpPulseInfo.noise_psd;
         pulseInfo.start_time_seconds = udpPulseInfo.start_time_seconds;

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -45,6 +45,14 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
 
     if (pulseInfo.frequency_hz == 0) {
         logInfo() << "HEARTBEAT from Detector" << pulseInfo.tag_id;
+    } else if ((uint8_t)udpPulseInfo.detection_status == 3) {
+        // No pulse detected this cycle — forward noise floor to GCS
+        pulseInfo.detection_status  = 3;
+        pulseInfo.confirmed_status  = 0;
+        pulseInfo.noise_psd         = udpPulseInfo.noise_psd;
+        pulseInfo.start_time_seconds = udpPulseInfo.start_time_seconds;
+        logDebug() << "NO DETECTION from Detector" << pulseInfo.tag_id
+                   << "noise_psd" << pulseInfo.noise_psd;
     } else {
         auto telemetry = _telemetryCache->telemetryForTime(udpPulseInfo.start_time_seconds);
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -38,6 +38,12 @@ from scipy.stats import gumbel_r
 
 K = 5  # Always 5-fold
 
+# Detection status values (mirrors TunnelProtocol.h detection_status field)
+DETECTION_STATUS_SUBTHRESHOLD  = 0  # Subthreshold pulse
+DETECTION_STATUS_SUPERTHRESHOLD = 1  # Superthreshold pulse
+DETECTION_STATUS_CONFIRMED     = 2  # Confirmed pulse
+DETECTION_STATUS_NO_DETECTION   = 3  # Searched but no pulse found
+
 # Global flag for graceful shutdown
 _should_stop = False
 
@@ -331,14 +337,19 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         evt_threshold_cache: dict with 'threshold' key (or None to regenerate)
 
     Returns:
-        List of (freq_hz, snr_db, phase_offset) sorted by SNR descending.
+        (detections, noise_psd) where:
+          detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score)
+                      sorted by SNR descending.
+          noise_psd:  float — median noise PSD across frequency bins when no
+                      detections are found; None when detections are present;
+                      NaN on early-exit error paths (insufficient data).
     """
     _, n_time = power.shape
 
     # Maximum valid first-pulse position
     max_start = n_time - (K - 1) * N
     if max_start <= 0:
-        return [], None
+        return [], float('nan')
     search_range = min(N, max_start)
 
     # Index matrix: (search_range, K) — each row is one candidate pattern
@@ -405,7 +416,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
             print(f'ERROR: Insufficient data for EVT threshold. '
                   f'Segment length ({n_time} samples) too short for K={K} folds.',
                   flush=True)
-            return [], None
+            return [], float('nan')
         evt_threshold_cache['threshold'] = base_threshold
     else:
         base_threshold = evt_threshold_cache['threshold']
@@ -610,6 +621,10 @@ def main():
             print(f'  Tag ID          {args.tag_id}')
         if args.freq:
             print(f'  Tag frequency   {args.freq} Hz')
+        else:
+            print('  Warning: --freq not set; pulse and no-detection reports '
+                  'will not be sent to the controller', file=sys.stderr,
+                  flush=True)
 
     # Install signal handler for graceful shutdown
     signal.signal(signal.SIGINT, _signal_handler)
@@ -845,7 +860,7 @@ def main():
                             group_seq_counter=cycle,
                             group_ind=0,
                             group_snr=snr_db,
-                            detection_status=1,
+                            detection_status=DETECTION_STATUS_SUPERTHRESHOLD,
                             confirmed_status=1,
                             noise_psd=noise_psd,
                         )
@@ -882,9 +897,9 @@ def main():
                         group_seq_counter=cycle,
                         group_ind=0,
                         group_snr=0.0,
-                        detection_status=3,
+                        detection_status=DETECTION_STATUS_NO_DETECTION,
                         confirmed_status=0,
-                        noise_psd=nodet_noise_psd if nodet_noise_psd is not None else 0.0,
+                        noise_psd=nodet_noise_psd,
                     )
                 print(f'[{cycle:4d} {ts_str}]  no detection  '
                       f'{proc_ms:.0f} ms{gap_flag}')

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -338,7 +338,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     # Maximum valid first-pulse position
     max_start = n_time - (K - 1) * N
     if max_start <= 0:
-        return []
+        return [], None
     search_range = min(N, max_start)
 
     # Index matrix: (search_range, K) — each row is one candidate pattern
@@ -405,7 +405,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
             print(f'ERROR: Insufficient data for EVT threshold. '
                   f'Segment length ({n_time} samples) too short for K={K} folds.',
                   flush=True)
-            return []
+            return [], None
         evt_threshold_cache['threshold'] = base_threshold
     else:
         base_threshold = evt_threshold_cache['threshold']
@@ -432,10 +432,6 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
                   f'ratio={score_thresh_ratio[idx]:.4f}  '
                   f'noise={noise_power[idx]:.4e}')
 
-    det_bins = np.where(best_scores > threshold)[0]
-    if len(det_bins) == 0:
-        return []
-
     # Frequency axis (DC-centred)
     freq_axis = Wf if Wf is not None else np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / Fs))
 
@@ -444,6 +440,12 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     # for a rectangular window with sum(w²) = n_w.  This matches the
     # normalisation used by uavrt_detection's wfmstft.
     psd_scale = float(Fs * n_w)
+
+    det_bins = np.where(best_scores > threshold)[0]
+    if len(det_bins) == 0:
+        # No detections — return median noise PSD so callers can report it
+        median_noise_psd = float(np.median(noise_power) / psd_scale)
+        return [], median_noise_psd
 
     results = []
     for b in det_bins:
@@ -475,7 +477,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         if len(merged) >= 1:
             break
 
-    return merged
+    return merged, None
 
 
 # ---------------------------------------------------------------------------
@@ -794,7 +796,8 @@ def main():
                 evt_threshold_cache['n_freq'] = n_freq_cur
                 evt_threshold_cache['n_time'] = n_time_cur
 
-            detections = fold_detect(power, N, args.pf, args.fs, nfft,
+            detections, nodet_noise_psd = fold_detect(
+                                     power, N, args.pf, args.fs, nfft,
                                      n_w, n_ol, samples_needed,
                                      evt_threshold_cache, W=W, Wf=Wf,
                                      debug=args.debug)
@@ -862,6 +865,27 @@ def main():
                               f'noise {noise_psd:.3e}  '
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}')
             else:
+                # Send a no-detection report so the controller/GCS knows
+                # we searched this cycle and found nothing.  Uses
+                # detection_status=3 (no pulse detected) — a dedicated
+                # status value that cannot be confused with a real pulse.
+                if pulse_sock is not None and args.freq:
+                    start_time_s = current_ts / 1e9 if current_ts else time.time()
+                    send_pulse_udp(
+                        pulse_sock, pulse_dest,
+                        tag_id=args.tag_id,
+                        frequency_hz=args.freq,
+                        start_time_seconds=start_time_s,
+                        predict_next_start_seconds=0.0,
+                        snr=0.0,
+                        stft_score=0.0,
+                        group_seq_counter=cycle,
+                        group_ind=0,
+                        group_snr=0.0,
+                        detection_status=3,
+                        confirmed_status=0,
+                        noise_psd=nodet_noise_psd if nodet_noise_psd is not None else 0.0,
+                    )
                 print(f'[{cycle:4d} {ts_str}]  no detection  '
                       f'{proc_ms:.0f} ms{gap_flag}')
 


### PR DESCRIPTION
When the detector completes a K-fold cycle without finding a pulse above the EVT threshold, it now sends a packet to the controller with `detection_status=3` so the controller and GCS can distinguish *searched but found nothing* from silence (no packets at all).

## Changes

### `detector/pulse_detector.py`
- `fold_detect()` now returns a tuple `(detections, noise_psd)`. On no-detection, `noise_psd` is the median noise PSD across all frequency bins.
- Main loop sends a `detection_status=3` packet on every empty cycle, carrying the observed noise floor in `noise_psd`.

### `controller/PulseHandler.cpp`
- New `else if` branch for `detection_status == 3`: logs at debug level (`NO DETECTION from Detector`), populates `noise_psd` and `start_time_seconds`, and forwards to GCS via MAVLink tunnel.
- Skips telemetry lookup (no real pulse position to attach).

### `tunnel-protocol` (submodule)
- Updated to latest `main` which includes the `detection_status=3` documentation (DonLakeFlyer/TagTrackerTunnelProtocol#2).

## Wire-format impact
No field layout or size change — `detection_status` is an existing `uint8_t` field. Value 3 is additive; consumers that don't recognise it will treat it as an unknown status (safe degradation).