### PR TITLE
Steepen simulator antenna gain pattern: 60° HPBW, 50 dB F/B

### DIFF
--- a/simulator/iq_simulator.py
+++ b/simulator/iq_simulator.py
@@ -96,8 +96,8 @@ class SimConfig:
     telemetry_sub_endpoint: str = "tcp://127.0.0.1:6001"  # ZMQ SUB endpoint for controller telemetry
     telemetry_topic: str = "vehicle_pose"
     tx_offset_north_m: float = 4000.0
-    ra2ahs_hpbw_deg: float = 100.0
-    ra2ahs_front_to_back_db: float = 12.0
+    ra2ahs_hpbw_deg: float = 60.0
+    ra2ahs_front_to_back_db: float = 50.0
 
 
 @dataclass


### PR DESCRIPTION
Changes the default simulated antenna pattern to produce a much steeper heading-dependent SNR falloff:

| Parameter | Before | After |
|-----------|--------|-------|
| `ra2ahs_hpbw_deg` | 100° | 60° |
| `ra2ahs_front_to_back_db` | 12 dB | 50 dB |

With 60° HPBW, the signal drops to half power at ±30° off boresight. With 50 dB front-to-back, the back lobe receives only 0.001% of the front lobe power — making directional variation clearly visible during simulated orbits.