### PR TITLE
Update full_setup.sh: remove stale repos, use Makefile, add venv setup

### DIFF
--- a/setup/full_setup.sh
+++ b/setup/full_setup.sh
@@ -4,7 +4,7 @@ set -e
 # wget https://raw.githubusercontent.com/DonLakeFlyer/MavlinkTagController2/main/setup/full_setup.sh
 
 echo "*** Install tools"
-sudo apt install build-essential git cmake libboost-all-dev libairspyhf-dev libfftw3-dev libzmq3-dev libusb-1.0-0-dev pkg-config -y
+sudo apt install build-essential git cmake libboost-all-dev libairspyhf-dev libzmq3-dev libusb-1.0-0-dev pkg-config python3 python3-venv -y
 git config --global pull.rebase false
 
 echo "*** Create repos directory"
@@ -17,43 +17,16 @@ cd ~/repos
 echo "*** Clone and build MavlinkTagController2 (controller + decimator + airspyhf_zeromq)"
 cd ~/repos
 if [ ! -d MavlinkTagController2 ]; then
-	git clone git@github.com:DonLakeFlyer/MavlinkTagController2.git
+	git clone --recurse-submodules git@github.com:DonLakeFlyer/MavlinkTagController2.git
 fi
 cd ~/repos/MavlinkTagController2
 git pull origin main
+git submodule update --init --recursive
 
-echo "*** Build all components"
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build -j4
-
-echo "*** Install airspyhf_zeromq"
-sudo cmake --install build
-sudo ldconfig
-
-echo "*** Clone and build csdr-uavrt"
-cd ~/repos
-if [ ! -d csdr-uavrt ]; then
-	git clone --recursive git@github.com:DonLakeFlyer/csdr-uavrt.git
-fi
-cd ~/repos/csdr-uavrt
-git pull origin master
-make -j4
-sudo make install
-
-echo "*** Clone and build airspy_channelize"
-cd ~/repos
-if [ ! -d airspy_channelize ]; then
-	git clone --recursive git@github.com:dynamic-and-active-systems-lab/airspy_channelize.git
-fi
-cd ~/repos/airspy_channelize
-git pull origin main
+echo "*** Build controller"
+rm -rf build
 make
 
-echo "*** Clone and build uavrt_detection"
-cd ~/repos
-if [ ! -d uavrt_detection ]; then
-	git clone --recursive git@github.com:dynamic-and-active-systems-lab/uavrt_detection.git
-fi
-cd ~/repos/uavrt_detection
-git pull origin main
-make
+echo "*** Set up Python virtual environment (detector + simulator)"
+cd ~/repos/MavlinkTagController2
+./setup_venv.sh

--- a/setup/full_setup.sh
+++ b/setup/full_setup.sh
@@ -23,7 +23,7 @@ cd ~/repos/MavlinkTagController2
 git pull origin main
 git submodule update --init --recursive
 
-echo "*** Build controller"
+echo "*** Build all components (controller, decimator, airspyhf_zeromq)"
 rm -rf build
 make
 


### PR DESCRIPTION
Brings `setup/full_setup.sh` in line with the current repo structure.

### Changes
- **Remove obsolete external repos** — `csdr-uavrt`, `airspy_channelize`, `uavrt_detection` no longer exist as separate clones; their functionality lives in this monorepo.
- **Add `python3` and `python3-venv`** to apt dependencies (needed for the detector and simulator).
- **Remove unused `libfftw3-dev`** — no longer required by any component.
- **Clone with `--recurse-submodules`** and run `git submodule update --init --recursive` to ensure `tunnel-protocol/` is populated.
- **Replace manual cmake commands with `make`** — uses the Makefile presets.
- **Add `./setup_venv.sh`** call to set up the Python virtual environment.