### PR TITLE
Update TelemetryCache maxK from 3 to 5 for Python detector

### DIFF
--- a/controller/TelemetryCache.cpp
+++ b/controller/TelemetryCache.cpp
@@ -69,7 +69,7 @@ void TelemetryCache::_pruneTelemetryCache()
     auto    nowMSecs            = std::chrono::duration_cast<std::chrono::milliseconds>(timeSince).count();
     double  nowSecs             = nowMSecs / 1000.0;
     double  maxIntraPulseSecs   = 5.0;
-    double  maxK                = 3.0;
+    double  maxK                = 5.0;
     double  pruneBeforeSecs     = nowSecs - (((maxK + 1) * maxIntraPulseSecs) * 2);
 
     while (_telemetryCache.size() > 0) {


### PR DESCRIPTION
Switched from uavrt_detection (K=3) to pulse_detector.py (K=5). Increase the telemetry cache pruning window from 40s to 60s so entries aren't pruned before the longer K=5 detection cycle completes.