### PR TITLE
Add AIRSPY_STATUS command, update submodule, simulator back-sector hack

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -611,6 +611,17 @@ void CommandHandler::_handleTunnelMessage(const mavlink_message_t& message)
     case COMMAND_ID_CLEAN_LOGS:
         success = _handleCleanLogs();
         break;
+    case COMMAND_ID_AIRSPY_STATUS:
+        if (_simulatorMode) {
+            success = true;
+        } else {
+            std::string errorMessage = _checkForAirSpy();
+            success = errorMessage.empty();
+            if (!success) {
+                ackMessage = errorMessage;
+            }
+        }
+        break;
     }
 
     _sendCommandAck(headerInfo.command, success ? COMMAND_RESULT_SUCCESS : COMMAND_RESULT_FAILURE, ackMessage);
@@ -821,6 +832,9 @@ std::string CommandHandler::_tunnelCommandIdToString(uint32_t command)
         break;
     case COMMAND_ID_CLEAN_LOGS:
         commandStr = "CLEAN_LOGS";
+        break;
+    case COMMAND_ID_AIRSPY_STATUS:
+        commandStr = "AIRSPY_STATUS";
         break;
     }
 

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -25,9 +25,10 @@ static constexpr uint8_t DETECTION_STATUS_NO_DETECTION = 3;
 using namespace TunnelProtocol;
 
 
-PulseHandler::PulseHandler(MavlinkSystem* mavlink, TelemetryCache* telemetryCache)
+PulseHandler::PulseHandler(MavlinkSystem* mavlink, TelemetryCache* telemetryCache, bool simulatorMode)
     : _mavlink          (mavlink)
     , _telemetryCache   (telemetryCache)
+    , _simulatorMode    (simulatorMode)
 {
 
 }
@@ -77,6 +78,20 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
         pulseInfo.orientation_y                 = telemetry.attitudeEuler.pitchDegrees;
         pulseInfo.orientation_z                 = telemetry.attitudeEuler.yawDegrees;
         pulseInfo.noise_psd                     = udpPulseInfo.noise_psd;
+
+        // Simulator hack: when pointing within 45° of directly away from
+        // the transmitter (assumed due north), force unconfirmed with low SNR.
+        if (_simulatorMode) {
+            float yaw = telemetry.attitudeEuler.yawDegrees;
+            // Normalize yaw-180 into [-180,180]
+            float offBack = std::fmod(yaw - 180.0f + 540.0f, 360.0f) - 180.0f;
+            if (std::fabs(offBack) < (180.0f - kBackSectorMinDeg)) {
+                pulseInfo.confirmed_status = 0;
+                pulseInfo.snr = 20.0;
+                pulseInfo.group_snr = 20.0;
+                pulseInfo.detection_status = 0; // subthreshold
+            }
+        }
 
         std::string pulseStatus = formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f stft_score: %5.1g noise_psd: %5.1g freq: %9u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
                                         pulseInfo.confirmed_status,

--- a/controller/PulseHandler.h
+++ b/controller/PulseHandler.h
@@ -14,7 +14,7 @@ class TelemetryCache;
 class PulseHandler
 {
 public:
-	PulseHandler(MavlinkSystem* mavlink, TelemetryCache* telemetryCache);
+	PulseHandler(MavlinkSystem* mavlink, TelemetryCache* telemetryCache, bool simulatorMode = false);
 	~PulseHandler();
 
 	// Enough for MTU 1500 bytes.
@@ -36,6 +36,9 @@ public:
 	void handlePulse(const UDPPulseInfo_T& udpPulseInfo);
 
 private:
+	static constexpr float kBackSectorMinDeg = 165.0f;
+
     MavlinkSystem*	_mavlink 		= nullptr;
 	TelemetryCache*	_telemetryCache	= nullptr;
+	bool			_simulatorMode	= false;
 };

--- a/controller/main.cpp
+++ b/controller/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
 
     auto ftpServer 			= MavlinkFtpServer { mavlink };
     auto telemetryCache     = new TelemetryCache(mavlink);
-	auto pulseHandler 		= new PulseHandler(mavlink, telemetryCache);
+	auto pulseHandler 		= new PulseHandler(mavlink, telemetryCache, simulatorMode);
     auto udpPulseReceiver   = UDPPulseReceiver { std::string("127.0.0.1"), CommandHandler::kPulseUdpPort, pulseHandler };
 
 	globalMavlinkSystem		= mavlink;

--- a/simulator/iq_simulator.py
+++ b/simulator/iq_simulator.py
@@ -368,14 +368,21 @@ def generate_packet(
                     tx_lon_deg,
                 )
                 off_boresight = _normalize_angle_deg(bearing_to_tx - vehicle_yaw_deg)
-                attenuation_db = _antenna_attenuation_db(
-                    off_boresight, cfg.antenna_max_attenuation_db
-                )
-                effective_snr_db = snr_at_distance(
-                    tag.snr_db,
-                    max(1.0, distance_m),
-                    ref_distance_m=max(1.0, cfg.tx_offset_north_m),
-                ) + attenuation_db
+
+                # Within 45° of pointing directly away: weaken signal to a
+                # fixed sub-threshold level so the detector produces only
+                # unconfirmed (confirmed=0) pulses rather than no detection.
+                if abs(off_boresight) > 135.0:
+                    effective_snr_db = 3.0
+                else:
+                    attenuation_db = _antenna_attenuation_db(
+                        off_boresight, cfg.antenna_max_attenuation_db
+                    )
+                    effective_snr_db = snr_at_distance(
+                        tag.snr_db,
+                        max(1.0, distance_m),
+                        ref_distance_m=max(1.0, cfg.tx_offset_north_m),
+                    ) + attenuation_db
 
         # Amplitude from SNR: snr_linear = (amp^2) / (noise_sigma^2)
         snr_linear = 10.0 ** (effective_snr_db / 10.0)

--- a/simulator/iq_simulator.py
+++ b/simulator/iq_simulator.py
@@ -368,21 +368,14 @@ def generate_packet(
                     tx_lon_deg,
                 )
                 off_boresight = _normalize_angle_deg(bearing_to_tx - vehicle_yaw_deg)
-
-                # Within 45° of pointing directly away: weaken signal to a
-                # fixed sub-threshold level so the detector produces only
-                # unconfirmed (confirmed=0) pulses rather than no detection.
-                if abs(off_boresight) > 135.0:
-                    effective_snr_db = 3.0
-                else:
-                    attenuation_db = _antenna_attenuation_db(
-                        off_boresight, cfg.antenna_max_attenuation_db
-                    )
-                    effective_snr_db = snr_at_distance(
-                        tag.snr_db,
-                        max(1.0, distance_m),
-                        ref_distance_m=max(1.0, cfg.tx_offset_north_m),
-                    ) + attenuation_db
+                attenuation_db = _antenna_attenuation_db(
+                    off_boresight, cfg.antenna_max_attenuation_db
+                )
+                effective_snr_db = snr_at_distance(
+                    tag.snr_db,
+                    max(1.0, distance_m),
+                    ref_distance_m=max(1.0, cfg.tx_offset_north_m),
+                ) + attenuation_db
 
         # Amplitude from SNR: snr_linear = (amp^2) / (noise_sigma^2)
         snr_linear = 10.0 ** (effective_snr_db / 10.0)


### PR DESCRIPTION
## Changes

- **Restore COMMAND_ID_AIRSPY_STATUS (14) dispatch** in CommandHandler
  - Returns success immediately in simulator mode
  - Runs `_checkForAirSpy()` in normal mode
  - Add command string mapping for logging

- **Update tunnel-protocol submodule** to latest origin/main
  (adds COMMAND_ID_AIRSPY_STATUS and AirspyStatusInfo_t)

- **PulseHandler back-sector simulator hack**: in simulator mode, when
  vehicle heading is within 15° of full back (180°), override pulses to
  confirmed_status=0, detection_status=0 (subthreshold), snr=20 dB

- **simulator/iq_simulator.py**: apply directional antenna model to all
  tags (remove i==0 restriction)