### PR TITLE
Improve controller logging

### DIFF
--- a/controller/MavlinkSystem.cpp
+++ b/controller/MavlinkSystem.cpp
@@ -17,7 +17,7 @@ MavlinkSystem::MavlinkSystem()
 {
 	// Force all output to Mavlink V2
 	mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(0);
-	mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;	
+	mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
 }
 
 MavlinkSystem::~MavlinkSystem()
@@ -125,7 +125,7 @@ void MavlinkSystem::sendStatusText(std::string& text, MAV_SEVERITY severity)
 	logInfo() << "statustext:" << text;
 
 	mavlink_statustext_t statustext;
-	
+
 	memset(&statustext, 0, sizeof(statustext));
 	statustext.severity = severity;
 
@@ -165,7 +165,7 @@ void MavlinkSystem::sendTunnelMessage(void* tunnelPayload, size_t tunnelPayloadS
     sendMessage(message);
 }
 
-std::optional<uint8_t> MavlinkSystem::ourSystemId() const 
+std::optional<uint8_t> MavlinkSystem::ourSystemId() const
 {
 	if (_connection.get()) {
 		return _connection->autopilotSystemId();
@@ -174,7 +174,7 @@ std::optional<uint8_t> MavlinkSystem::ourSystemId() const
 	}
 }
 
-std::optional<uint8_t> MavlinkSystem::gcsSystemId() const 
+std::optional<uint8_t> MavlinkSystem::gcsSystemId() const
 {
 	if (_connection.get()) {
 		return _connection->gcsSystemId();
@@ -213,7 +213,7 @@ float MavlinkSystem::_cpuTemp()
 void MavlinkSystem::startTunnelHeartbeatSender()
 {
     std::thread heartbeatSenderThread([this]() {
-        int cpuWaitCount = 0;
+        int heartbeatCount = 0;
 
         while (true) {
             TunnelProtocol::Heartbeat_t heartbeat;
@@ -225,9 +225,9 @@ void MavlinkSystem::startTunnelHeartbeatSender()
 
             sendTunnelMessage(&heartbeat, sizeof(heartbeat));
 
-            if (cpuWaitCount-- <= 0) {
-                cpuWaitCount = 30;
-        		logInfo() << "CPU Temperature: " << _cpuTemp() << "°C";
+            if (++heartbeatCount >= 60) {
+        		logInfo() << "Sent" << heartbeatCount << "tunnel heartbeats, status:" << _heartbeatStatus << " cpu_temp:" << heartbeat.cpu_temp_c;
+                heartbeatCount = 0;
             }
 
             std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/controller/MavlinkSystem.h
+++ b/controller/MavlinkSystem.h
@@ -46,8 +46,8 @@ public:
 	void 						sendTunnelMessage			(void* tunnelPayload, size_t tunnelPayloadSize);
 	void 						sendMessage					(const mavlink_message_t& message);
 	Telemetry& 					telemetry					() { return _telemetry; }
-	uint16_t 					heartbeatStatus				() const { return _heartbeatStatus; }
-	void						setHeartbeatStatus			(uint16_t heartbeatStatus) { _heartbeatStatus = heartbeatStatus; }
+	uint16_t 					heartbeatStatus				() const { return _heartbeatStatus.load(); }
+	void						setHeartbeatStatus			(uint16_t heartbeatStatus) { _heartbeatStatus.store(heartbeatStatus); }
 
 private:
 	MavlinkSystem();
@@ -63,7 +63,7 @@ private:
 	std::unique_ptr<Connection> _connection {};
 	std::mutex 					_subscriptions_mutex {};
 	Telemetry 					_telemetry;
-	uint16_t					_heartbeatStatus { HEARTBEAT_STATUS_IDLE };
+	std::atomic<uint16_t>		_heartbeatStatus { HEARTBEAT_STATUS_IDLE };
 
 	friend class MavlinkOutgoingMessageQueue;
 };

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -93,7 +93,7 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
             }
         }
 
-        std::string pulseStatus = formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f stft_score: %5.1g noise_psd: %5.1g freq: %9u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
+        std::string pulseStatus = formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f stft_score: %5.1g noise_psd: %5.1g freq: %9u seq: %u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
                                         pulseInfo.confirmed_status,
                                         pulseInfo.tag_id,
                                         pulseInfo.snr,
@@ -101,6 +101,7 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
                                         pulseInfo.stft_score,
                                         pulseInfo.noise_psd,
                                         pulseInfo.frequency_hz,
+                                        pulseInfo.group_seq_counter,
                                         telemetry.position.latitude,
                                         telemetry.position.longitude,
                                         telemetry.attitudeEuler.yawDegrees,


### PR DESCRIPTION
## Changes

- **Pulse log**: Add `group_seq_counter` (seq) to the pulse log line for debugging cycle tracking
- **Heartbeat log**: Replace per-second tunnel heartbeat log with a once-per-minute summary showing send count, status, and CPU temp

No functional changes to message content or timing.