### PR TITLE
Add signal analyzer for pulse width and repetition rate

### DIFF
--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -1,0 +1,76 @@
+# Signal Analyzer
+
+Detect a strong pulsed signal at a specific frequency and measure its **pulse width** (ms) and **repetition rate** (Hz / interval in seconds).
+
+## Pipeline
+
+Uses the same Airspy HF+ SDR pipeline as the pulse detector:
+
+```
+airspyhf_zeromq_rx  →  [ZMQ]  →  decimator  →  [UDP]  →  signal_analyzer.py
+```
+
+`run_analyzer.sh` starts all three processes automatically.
+
+## Algorithm
+
+1. Accumulate IQ samples for the analysis window (default 10 s)
+2. Find the strongest frequency via full-segment FFT (excluding DC spike)
+3. Mix to baseband at that frequency
+4. Compute instantaneous power (`I² + Q²`), then lowpass filter to get a smooth envelope
+5. Threshold the envelope to find on/off transitions
+6. Measure pulse widths and start-to-start intervals from transitions
+
+## Usage
+
+```bash
+# Basic — specify the expected signal frequency:
+./run_analyzer.sh --expected-freq 148.515
+
+# With a longer analysis window:
+./run_analyzer.sh --expected-freq 148.515 --duration 15
+
+# Override detection threshold (dB above noise):
+./run_analyzer.sh --expected-freq 148.515 --threshold 12
+```
+
+Ctrl-C stops all three pipeline processes.
+
+## DC Spike Avoidance
+
+The radio is automatically tuned 10 kHz above `--expected-freq` so the signal of interest lands away from the SDR's DC spike. The decimator's `--shift-khz 10` moves the radio's DC to the edge of the decimated band.
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--expected-freq` | *(required)* | Expected signal frequency in MHz |
+| `--duration` | 10 | Analysis window in seconds |
+| `--threshold` | 10 | Detection threshold (dB above noise floor) |
+| `--freq-offset` | auto | Baseband frequency offset in Hz (auto-detects strongest peak) |
+| `--port` | 10001 | UDP port for decimated IQ |
+| `--fs` | 3840 | Decimated sample rate in Hz |
+
+## Prerequisites
+
+- Built `airspyhf_zeromq_rx` and `airspyhf_decimator` (`cmake --build build`)
+- Python venv with `numpy` (`./setup_venv.sh`)
+- Airspy HF+ SDR connected
+
+## Output
+
+```
+[ana] === Signal Analyzer (Airspy HF+) ===
+[ana]   Expected freq   148.515000 MHz
+[ana]   Sample rate     3840.0 Hz
+[ana]   Analysis window 10.0 s
+[ana] [   1 17:02:14]  148.515012 MHz (+12.3 Hz)  5 pulses  width=14.8 ms  [14.6, 15.1, 14.8, 15.0, 14.6]  interval=2.001 s  rate=0.500 Hz  (10.0s window, 25 ms)
+```
+
+On exit, prints aggregate statistics:
+
+```
+--- Analysis complete: 6 cycles ---
+  Pulse width:     mean=14.82 ms  median=14.84 ms  std=0.21 ms  (n=30)
+  Repetition:      mean=2.0008 s  (0.4998 Hz)  std=0.0012 s  (n=24)
+```

--- a/analyzer/run_analyzer.sh
+++ b/analyzer/run_analyzer.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Run the full signal analysis pipeline with Airspy HF+:
+#
+#   airspyhf_zeromq_rx  →  [ZMQ]  →  decimator  →  [UDP]  →  signal_analyzer.py
+#
+# The radio is tuned 10 kHz above the expected frequency so the signal
+# lands away from the DC spike in the decimated output.
+#
+# Usage:
+#   ./run_analyzer.sh --expected-freq 148.515
+#   ./run_analyzer.sh --expected-freq 148.515 --duration 15
+#
+# Stop:   Ctrl-C (kills all three processes)
+#
+# All extra arguments are forwarded to signal_analyzer.py.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_DIR/build"
+
+RX="$BUILD_DIR/airspyhf_zeromq/tools/src/airspyhf_zeromq_rx"
+DEC="$BUILD_DIR/decimator/airspyhf_decimator"
+ANALYZER="$SCRIPT_DIR/signal_analyzer.py"
+
+ZMQ_PORT=5555
+UDP_PORT=10001        # Different from detector default to allow both
+SHIFT_KHZ=10          # Tune offset to avoid DC spike
+
+# --- Activate venv if present ---
+if [ -f "$REPO_DIR/.venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/.venv/bin/activate"
+fi
+
+# --- Parse --expected-freq from args so we can compute radio freq ---
+EXPECTED_FREQ=""
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --expected-freq)
+            EXPECTED_FREQ="$2"
+            EXTRA_ARGS+=("$1" "$2")
+            shift 2
+            ;;
+        --port)
+            UDP_PORT="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$EXPECTED_FREQ" ]; then
+    echo "Error: --expected-freq is required (e.g. --expected-freq 148.515)" >&2
+    echo "Usage: $0 --expected-freq <MHz> [signal_analyzer.py options]" >&2
+    exit 1
+fi
+
+# Radio tunes 10 kHz above expected so decimator --shift-khz 10 places
+# the expected frequency at DC in the decimated output, away from the
+# radio's own DC spike.
+RADIO_FREQ=$(python3 -c "print(f'{${EXPECTED_FREQ} + ${SHIFT_KHZ}/1000.0:.6f}')")
+
+# --- preflight checks ---
+for bin in "$RX" "$DEC"; do
+    if [ ! -x "$bin" ]; then
+        echo "Error: $bin not found or not executable. Run: cmake --build build" >&2
+        exit 1
+    fi
+done
+if ! command -v python3 &>/dev/null; then
+    echo "Error: python3 not found" >&2
+    exit 1
+fi
+
+# --- cleanup on exit ---
+PIDS=()
+cleanup() {
+    echo ""
+    echo "Stopping pipeline..."
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    for pid in "${PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            sleep 0.5
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Process $pid did not terminate, sending SIGKILL..."
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    done
+    wait 2>/dev/null || true
+    echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Signal Analyzer Pipeline ==="
+echo "  Expected freq   ${EXPECTED_FREQ} MHz"
+echo "  Radio tuned to  ${RADIO_FREQ} MHz (+${SHIFT_KHZ} kHz offset)"
+echo "  ZMQ port        ${ZMQ_PORT}"
+echo "  UDP port        ${UDP_PORT}"
+echo ""
+
+# --- 1. airspy HF+ ZMQ reader ---
+echo "Starting airspyhf_zeromq_rx at ${RADIO_FREQ} MHz (ZMQ port ${ZMQ_PORT})..."
+"$RX" -f "$RADIO_FREQ" -P "$ZMQ_PORT" 2>&1 | sed 's/^/[rx]  /' &
+PIDS+=($!)
+sleep 1
+
+# --- 2. decimator ---
+echo "Starting decimator (ZMQ → UDP:${UDP_PORT})..."
+"$DEC" \
+    --zmq-endpoint "tcp://127.0.0.1:${ZMQ_PORT}" \
+    --ports "$UDP_PORT" \
+    --shift-khz "$SHIFT_KHZ" \
+    2>&1 | grep -v '^.*: perf ' | sed 's/^/[dec] /' &
+PIDS+=($!)
+sleep 1
+
+# --- 3. signal analyzer ---
+echo "Starting signal analyzer (expected ${EXPECTED_FREQ} MHz)..."
+echo ""
+python3 -u "$ANALYZER" \
+    --port "$UDP_PORT" \
+    "${EXTRA_ARGS[@]}" \
+    2>&1 | sed -u 's/^/[ana] /'

--- a/analyzer/signal_analyzer.py
+++ b/analyzer/signal_analyzer.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""
+Signal Analyzer — detect a strong signal at a specific frequency and measure
+pulse width (ms) and repetition rate (Hz / interval in seconds).
+
+Reads decimated IQ data from the Airspy HF+ pipeline (same as pulse_detector.py):
+
+  airspyhf_zeromq_rx  →  [ZMQ]  →  decimator  →  [UDP]  →  this script
+
+Algorithm:
+  1. Compute STFT of incoming IQ stream
+  2. Find the strongest frequency bin (or use --freq-offset)
+  3. Extract the power time-series at that bin
+  4. Threshold the power to find on/off transitions
+  5. Measure pulse widths and inter-pulse intervals from transitions
+
+The radio must be tuned offset from the expected frequency to avoid the DC
+spike.  The decimator's --shift-khz places a specific offset at DC in the
+decimated output.  This script computes the expected frequency's position
+in the decimated baseband automatically.
+
+Examples:
+  # Radio at 148.525 MHz, decimator --shift-khz 10, tag at 148.515 MHz:
+  python signal_analyzer.py --expected-freq 148.515 --port 10000
+
+  # Override the frequency offset manually:
+  python signal_analyzer.py --expected-freq 148.515 --freq-offset 200 --port 10000
+"""
+
+import argparse
+import datetime
+import signal
+import socket
+import struct
+import sys
+import time
+
+import numpy as np
+
+# Global flag for graceful shutdown
+_should_stop = False
+
+
+def _signal_handler(signum, frame):
+    global _should_stop
+    _should_stop = True
+
+
+# ---------------------------------------------------------------------------
+# UDP packet decoding (same as pulse_detector.py)
+# ---------------------------------------------------------------------------
+
+def decode_timestamp(raw_8bytes):
+    """Decode wall-clock timestamp from the decimator's first-sample header.
+
+    Returns timestamp in nanoseconds as an integer.
+    """
+    i_f, q_f = struct.unpack('<ff', raw_8bytes)
+    sec  = struct.unpack('<I', struct.pack('<f', i_f))[0]
+    nsec = struct.unpack('<I', struct.pack('<f', q_f))[0]
+    return sec * 1_000_000_000 + nsec
+
+
+# ---------------------------------------------------------------------------
+# Envelope detection (mix to baseband + lowpass)
+# ---------------------------------------------------------------------------
+
+def extract_envelope(iq, Fs, freq_hz, lpf_cutoff_hz=30.0):
+    """Extract the power envelope at a specific frequency.
+
+    Mixes the signal to baseband at freq_hz, lowpass filters, and returns
+    the power envelope at the full sample rate.
+
+    Args:
+        iq:             1-D complex64 array
+        Fs:             Sample rate in Hz
+        freq_hz:        Frequency to extract (Hz offset from DC)
+        lpf_cutoff_hz:  Lowpass filter cutoff in Hz (default: 30)
+
+    Returns:
+        envelope: 1-D float32 array of power values at sample rate Fs
+    """
+    n = len(iq)
+    t = np.arange(n, dtype=np.float64) / Fs
+
+    # Mix to baseband: shift the target frequency to DC
+    mixed = iq * np.exp(-2j * np.pi * freq_hz * t).astype(np.complex64)
+
+    # Compute instantaneous power first, then smooth.
+    # This avoids residual carrier ripple that would occur from filtering
+    # I/Q separately when the frequency estimate is imperfect.
+    inst_power = (mixed.real**2 + mixed.imag**2).astype(np.float64)
+
+    # Moving-average lowpass filter on the power envelope.
+    # At 3840 Hz with 30 Hz cutoff → 128-sample kernel (~33 ms).
+    # This smooths out noise while preserving 15 ms pulse edges adequately.
+    kernel_len = max(int(Fs / lpf_cutoff_hz), 3)
+    if kernel_len % 2 == 0:
+        kernel_len += 1
+    kernel = np.ones(kernel_len, dtype=np.float64) / kernel_len
+
+    envelope = np.convolve(inst_power, kernel, mode='same')
+    return envelope.astype(np.float32)
+
+
+def find_peak_frequency_fft(iq, Fs, exclude_dc_hz=50.0):
+    """Find the strongest frequency in the IQ segment using a full FFT.
+
+    Args:
+        iq:             1-D complex array
+        Fs:             Sample rate in Hz
+        exclude_dc_hz:  Exclude frequencies within this range of DC
+
+    Returns:
+        peak_freq_hz: float
+    """
+    n = len(iq)
+    S = np.fft.fftshift(np.fft.fft(iq))
+    power = (S.real**2 + S.imag**2).astype(np.float64)
+    freq_axis = np.fft.fftshift(np.fft.fftfreq(n, d=1.0 / Fs))
+
+    # Mask DC region
+    dc_mask = np.abs(freq_axis) < exclude_dc_hz
+    power[dc_mask] = 0
+
+    peak_bin = np.argmax(power)
+    return float(freq_axis[peak_bin])
+
+
+# ---------------------------------------------------------------------------
+# Pulse measurement
+# ---------------------------------------------------------------------------
+
+def measure_pulses(power_time_series, time_step_s, threshold_db_above_noise=6.0):
+    """Detect on/off transitions in a power time series and measure pulses.
+
+    Args:
+        power_time_series: 1-D array of power values at one frequency bin
+        time_step_s:       Time between consecutive power samples (seconds)
+        threshold_db_above_noise: dB above noise floor to consider "on"
+
+    Returns:
+        dict with:
+          pulse_widths_ms:   list of pulse widths in milliseconds
+          intervals_s:       list of pulse-to-pulse intervals in seconds
+          rep_rate_hz:       repetition rate (1/mean_interval), or None
+          mean_pulse_ms:     mean pulse width in ms, or None
+          median_pulse_ms:   median pulse width in ms, or None
+          mean_interval_s:   mean interval in seconds, or None
+    """
+    if len(power_time_series) < 3:
+        return _empty_result()
+
+    # Estimate noise floor as the 25th percentile of power (robust to pulses)
+    noise_floor = np.percentile(power_time_series, 25)
+    if noise_floor <= 0:
+        noise_floor = np.min(power_time_series[power_time_series > 0])
+        if noise_floor <= 0:
+            return _empty_result()
+
+    threshold_linear = noise_floor * (10.0 ** (threshold_db_above_noise / 10.0))
+
+    # Boolean mask: True where signal is above threshold
+    is_on = power_time_series > threshold_linear
+
+    # Find transitions
+    transitions = np.diff(is_on.astype(np.int8))
+    rise_indices = np.where(transitions == 1)[0] + 1   # rising edge
+    fall_indices = np.where(transitions == -1)[0] + 1   # falling edge
+
+    # If signal starts high, add a rising edge at index 0
+    if is_on[0]:
+        rise_indices = np.concatenate(([0], rise_indices))
+    # If signal ends high, add a falling edge at the end
+    if is_on[-1]:
+        fall_indices = np.concatenate((fall_indices, [len(is_on)]))
+
+    # Pair up rises and falls
+    pulse_widths_ms = []
+    pulse_starts = []
+
+    n_pulses = min(len(rise_indices), len(fall_indices))
+    for i in range(n_pulses):
+        rise = rise_indices[i]
+        # Find the first fall after this rise
+        falls_after = fall_indices[fall_indices > rise]
+        if len(falls_after) == 0:
+            break
+        fall = falls_after[0]
+        width_s = (fall - rise) * time_step_s
+        pulse_widths_ms.append(width_s * 1000.0)
+        pulse_starts.append(rise * time_step_s)
+
+    # Inter-pulse intervals (start-to-start)
+    intervals_s = []
+    for i in range(1, len(pulse_starts)):
+        intervals_s.append(pulse_starts[i] - pulse_starts[i - 1])
+
+    result = {
+        'pulse_widths_ms': pulse_widths_ms,
+        'intervals_s': intervals_s,
+        'noise_floor': noise_floor,
+        'threshold': threshold_linear,
+        'n_pulses': len(pulse_widths_ms),
+    }
+
+    if pulse_widths_ms:
+        result['mean_pulse_ms'] = np.mean(pulse_widths_ms)
+        result['median_pulse_ms'] = np.median(pulse_widths_ms)
+    else:
+        result['mean_pulse_ms'] = None
+        result['median_pulse_ms'] = None
+
+    if intervals_s:
+        result['mean_interval_s'] = np.mean(intervals_s)
+        result['rep_rate_hz'] = 1.0 / np.mean(intervals_s)
+    else:
+        result['mean_interval_s'] = None
+        result['rep_rate_hz'] = None
+
+    return result
+
+
+def _empty_result():
+    return {
+        'pulse_widths_ms': [],
+        'intervals_s': [],
+        'noise_floor': None,
+        'threshold': None,
+        'n_pulses': 0,
+        'mean_pulse_ms': None,
+        'median_pulse_ms': None,
+        'mean_interval_s': None,
+        'rep_rate_hz': None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+
+def print_measurements(cycle, ts_str, meas, freq_display, proc_ms, segment_s):
+    """Print a summary line for one analysis cycle."""
+    if meas['n_pulses'] == 0:
+        print(f'[{cycle:4d} {ts_str}]  {freq_display}  '
+              f'no pulses detected  ({segment_s:.1f}s window, {proc_ms:.0f} ms)',
+              flush=True)
+        return
+
+    pw_str = f'{meas["median_pulse_ms"]:.1f}' if meas['median_pulse_ms'] else '?'
+    interval_str = f'{meas["mean_interval_s"]:.3f}' if meas['mean_interval_s'] else '?'
+    rate_str = f'{meas["rep_rate_hz"]:.3f}' if meas['rep_rate_hz'] else '?'
+
+    # Show individual pulse widths if few enough
+    if meas['n_pulses'] <= 8:
+        widths = ', '.join(f'{w:.1f}' for w in meas['pulse_widths_ms'])
+        pw_detail = f'  [{widths}]'
+    else:
+        pw_detail = ''
+
+    print(f'[{cycle:4d} {ts_str}]  {freq_display}  '
+          f'{meas["n_pulses"]} pulses  '
+          f'width={pw_str} ms{pw_detail}  '
+          f'interval={interval_str} s  '
+          f'rate={rate_str} Hz  '
+          f'({segment_s:.1f}s window, {proc_ms:.0f} ms)',
+          flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run(args):
+    """Run analyzer reading from the Airspy HF+ decimator UDP pipeline."""
+    global _should_stop
+
+    Fs = args.fs
+    analysis_duration = args.duration
+    samples_needed = int(Fs * analysis_duration)
+    time_step = 1.0 / Fs  # Envelope is at full sample rate
+
+    # The decimator centers DC at the radio tune frequency + shift-khz.
+    # The expected signal will appear at an offset from DC in the decimated
+    # baseband.  If --freq-offset is not given, auto-detect the peak.
+    expected_freq_mhz = args.expected_freq
+
+    print('=== Signal Analyzer (Airspy HF+) ===')
+    print(f'  Expected freq   {expected_freq_mhz:.6f} MHz')
+    print(f'  Sample rate     {Fs:.1f} Hz')
+    print(f'  Analysis window {analysis_duration:.1f} s')
+    print(f'  Time resolution {time_step*1000:.2f} ms (envelope at sample rate)')
+    print(f'  Freq resolution {Fs/samples_needed:.4f} Hz (full-segment FFT)')
+    print(f'  Samples/window  {samples_needed}')
+    print(f'  UDP port        {args.port}')
+    if args.freq_offset is not None:
+        print(f'  Freq offset     {args.freq_offset:.1f} Hz (manual)')
+    else:
+        print(f'  Freq offset     auto-detect (avoid DC spike)')
+    print(f'  Threshold       {args.threshold:.1f} dB above noise')
+    print()
+
+    # UDP socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    recv_buf_bytes = 1 << 20
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, recv_buf_bytes)
+    except OSError:
+        pass
+    sock.bind(('0.0.0.0', args.port))
+    sock.settimeout(2.0)
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    buf_parts = []
+    buf_len = 0
+    seg_ts = None
+    cycle = 0
+    total_packets = 0
+    total_samples = 0
+    last_status_time = time.monotonic()
+
+    # Running stats for summary
+    all_widths = []
+    all_intervals = []
+
+    print('Waiting for data ...\n')
+
+    try:
+        while not _should_stop:
+            try:
+                data = sock.recv(65536)
+            except socket.timeout:
+                now = time.monotonic()
+                if total_packets == 0 and now - last_status_time > 5.0:
+                    print('  (no data received yet — check pipeline is running)',
+                          flush=True)
+                    last_status_time = now
+                elif total_packets > 0 and now - last_status_time > 5.0:
+                    print(f'  (timeout — no data for 2s, '
+                          f'{total_packets} packets/{total_samples} samples so far)',
+                          flush=True)
+                    last_status_time = now
+                continue
+            if len(data) < 16:
+                continue
+
+            try:
+                ts = decode_timestamp(data[:8])
+            except (struct.error, ValueError):
+                continue
+
+            if seg_ts is None:
+                seg_ts = ts
+
+            payload = data[8:]
+            n_samp = len(payload) // 8
+            if n_samp == 0:
+                continue
+
+            iq = np.frombuffer(payload[:n_samp * 8],
+                               dtype=np.complex64).copy()
+            buf_parts.append(iq)
+            buf_len += n_samp
+            total_packets += 1
+            total_samples += n_samp
+
+            # Log first packet and periodic status
+            if total_packets == 1:
+                print(f'  Receiving data: first packet {n_samp} samples',
+                      flush=True)
+            now = time.monotonic()
+            if now - last_status_time > 5.0:
+                pct = 100.0 * buf_len / samples_needed
+                print(f'  Buffering: {buf_len}/{samples_needed} samples '
+                      f'({pct:.0f}%)  [{total_packets} packets received]',
+                      flush=True)
+                last_status_time = now
+
+            if buf_len < samples_needed:
+                continue
+
+            cycle += 1
+            t0 = time.monotonic()
+
+            segment = np.concatenate(buf_parts)[:samples_needed]
+            buf_parts.clear()
+            buf_len = 0
+
+            # Find or use specified frequency
+            if args.freq_offset is not None:
+                peak_freq = args.freq_offset
+            else:
+                peak_freq = find_peak_frequency_fft(segment, Fs)
+
+            # Extract power envelope at the target frequency
+            envelope = extract_envelope(segment, Fs, peak_freq)
+
+            # Measure pulses from the envelope
+            meas = measure_pulses(envelope, time_step, args.threshold)
+
+            proc_ms = (time.monotonic() - t0) * 1000.0
+
+            # Format frequency display
+            abs_mhz = expected_freq_mhz + peak_freq / 1e6
+            freq_display = f'{abs_mhz:.6f} MHz ({peak_freq:+.1f} Hz)'
+
+            # Timestamp
+            ts_str = ''
+            if seg_ts and seg_ts > 1e9:
+                ts_str = datetime.datetime.fromtimestamp(
+                    seg_ts / 1e9, tz=datetime.timezone.utc
+                ).strftime('%H:%M:%S')
+            seg_ts = None
+
+            print_measurements(cycle, ts_str, meas, freq_display,
+                               proc_ms, analysis_duration)
+
+            all_widths.extend(meas['pulse_widths_ms'])
+            all_intervals.extend(meas['intervals_s'])
+
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sock.close()
+        _print_summary(cycle, all_widths, all_intervals)
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+def _print_summary(cycle, all_widths, all_intervals):
+    """Print aggregate statistics."""
+    print(f'\n--- Analysis complete: {cycle} cycles ---', flush=True)
+
+    if all_widths:
+        w = np.array(all_widths)
+        print(f'  Pulse width:     mean={np.mean(w):.2f} ms  '
+              f'median={np.median(w):.2f} ms  '
+              f'std={np.std(w):.2f} ms  '
+              f'(n={len(w)})', flush=True)
+    else:
+        print('  Pulse width:     no pulses detected', flush=True)
+
+    if all_intervals:
+        iv = np.array(all_intervals)
+        print(f'  Repetition:      mean={np.mean(iv):.4f} s  '
+              f'({1.0/np.mean(iv):.4f} Hz)  '
+              f'std={np.std(iv):.4f} s  '
+              f'(n={len(iv)})', flush=True)
+    else:
+        print('  Repetition:      insufficient data', flush=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Signal Analyzer — measure pulse width and repetition rate',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__)
+
+    ap.add_argument('--expected-freq', type=float, required=True,
+                    help='Expected signal frequency in MHz (e.g. 148.515). '
+                         'The radio should be tuned offset from this to avoid '
+                         'the DC spike.')
+    ap.add_argument('--duration', type=float, default=10.0,
+                    help='Analysis window duration in seconds (default: 10)')
+    ap.add_argument('--threshold', type=float, default=10.0,
+                    help='Detection threshold in dB above noise floor (default: 10)')
+    ap.add_argument('--freq-offset', type=float, default=None,
+                    help='Frequency offset in Hz to monitor in decimated baseband '
+                         '(default: auto-detect strongest peak, excluding DC)')
+    ap.add_argument('--port', type=int, default=10000,
+                    help='UDP port for decimated IQ (default: 10000)')
+    ap.add_argument('--fs', type=float, default=3840.0,
+                    help='Decimated sample rate in Hz (default: 3840)')
+
+    args = ap.parse_args()
+    run(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New `analyzer/` directory with a signal analyzer that detects strong pulsed signals and measures:

- **Pulse width** (ms)
- **Repetition rate** (Hz / interval in seconds)

## Pipeline

Uses the same Airspy HF+ decimator pipeline as the existing pulse detector:

```
airspyhf_zeromq_rx → [ZMQ] → decimator → [UDP] → signal_analyzer.py
```

`run_analyzer.sh` starts all three processes automatically.

## Algorithm

1. Accumulate IQ samples for the analysis window (default 10 s)
2. Full-segment FFT to find strongest frequency (excluding DC spike)
3. Mix to baseband → instantaneous power (I² + Q²) → lowpass filter
4. Threshold envelope to find on/off transitions → measure widths and intervals

## Usage

```bash
./analyzer/run_analyzer.sh --expected-freq 148.515
```

## Files

- `signal_analyzer.py` — main analyzer script
- `run_analyzer.sh` — pipeline launcher (radio tuned +10 kHz to avoid DC spike)
- `README.md` — documentation
