### PR TITLE
Raw capture frequency_hz, metadata JSON, and logging improvements

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -443,60 +443,107 @@ std::string CommandHandler::_handleRawCapture(const mavlink_tunnel_t& tunnel)
         return "Raw capture not supported in simulator mode";
     }
 
-    if (_tagDatabase.size() == 0) {
-        logError() << "COMMAND_ID_RAW_CAPTURE - ERROR: No tags configured";
-        return "No tags configured";
+    RawCaptureInfo_t rawCaptureCmd;
+    memcpy(&rawCaptureCmd, tunnel.payload, sizeof(rawCaptureCmd));
+
+    if (rawCaptureCmd.frequency_hz == 0 && _tagDatabase.size() == 0) {
+        logError() << "COMMAND_ID_RAW_CAPTURE - ERROR: No frequency specified and no tags configured";
+        return "No frequency specified and no tags configured";
     }
 
-    std::thread([this, tunnel, deviceType]() {
-        RawCaptureInfo_t    rawCapture;
-        double              frequencyMhz = (double)_tagDatabase[0].frequency_hz / 1000000.0;
+    std::thread([this, rawCaptureCmd, deviceType]() {
+        RawCaptureInfo_t    rawCapture = rawCaptureCmd;
+        double              frequencyMhz = rawCapture.frequency_hz != 0
+                                            ? (double)rawCapture.frequency_hz / 1000000.0
+                                            : (double)_tagDatabase[0].frequency_hz / 1000000.0;
         auto                logFileManager = LogFileManager::instance();
 
         logFileManager->rawCaptureStarted();
         auto logDir = logFileManager->logDir(LogFileManager::RAW_CAPTURE);
 
-        memcpy(&rawCapture, tunnel.payload, sizeof(rawCapture));
-
         ++_rawCaptureCount;
 
         std::string commandStr;
         std::string captureLogPath;
+        std::string captureDataPath;
         std::string sdrPathStatus;
         std::string processName;
+        std::string sdrType;
+        int         sampleRate = 0;
+        int         gain = 0;
+        double      tuneFreqMhz = 0;
+        double      dcOffsetHz = 0;
 
-        const int sampleDurationSeconds = 8;
+        const int sampleDurationSeconds = 13;
         if (deviceType == AirSpyDeviceType::HF) {
             // AGC off, LNA on
-            const int sampleRate = 768000; // 768 ksps is the default sample rate for AirSpy HF
+            sampleRate = 768000; // 768 ksps is the default sample rate for AirSpy HF
             const int numSamples = sampleRate * sampleDurationSeconds;
+            dcOffsetHz = static_cast<double>(kAirSpyHfFrequencyOffsetHz);
+            tuneFreqMhz = frequencyMhz + (dcOffsetHz / 1000000.0);
             // Match start-detection tuning: capture 10 kHz above requested center to avoid the DC spike at baseband.
             // Post-processing can account for the same +10 kHz offset when interpreting frequency bins.
-            commandStr = formatString("%s/repos/MavlinkTagController2/build/airspyhf_zeromq/tools/src/airspyhf_zeromq_rx -r %s/airspy-hf.%d.dat -f %f -a 768000 -g off -m on -n %d",
+            captureDataPath = formatString("%s/airspy-hf.%d.dat", logDir.c_str(), _rawCaptureCount);
+            commandStr = formatString("%s/repos/MavlinkTagController2/build/airspyhf_zeromq/tools/src/airspyhf_zeromq_rx -r %s -f %f -a 768000 -g off -m on -n %d",
                                       _homePath,
-                                      logDir.c_str(),
-                                      _rawCaptureCount,
-                                      frequencyMhz + (static_cast<double>(kAirSpyHfFrequencyOffsetHz) / 1000000.0),
+                                      captureDataPath.c_str(),
+                                      tuneFreqMhz,
                                       numSamples);
             captureLogPath = formatString("%s/airspy-hf.%d.log", logDir.c_str(), _rawCaptureCount);
             sdrPathStatus = _sdrPathStatusText(deviceType, frequencyMhz);
             processName = "airspy-hf-capture";
+            sdrType = "airspy_hf";
             logInfo() << "COMMAND_ID_RAW_CAPTURE - using AirSpy HF ZeroMQ capture command";
         } else {
-            const int sampleRate = 3000000; // 3 Msps
+            sampleRate = 3000000; // 3 Msps
             const int numSamples = sampleRate * sampleDurationSeconds;
+            tuneFreqMhz = frequencyMhz;
+            gain = rawCapture.gain;
 
-            commandStr = formatString("%sairspy_rx -r %s/airspy-mini.%d.dat -f %f -a 3000000 -h %d -t 0 -n %d",
+            captureDataPath = formatString("%s/airspy-mini.%d.dat", logDir.c_str(), _rawCaptureCount);
+            commandStr = formatString("%sairspy_rx -r %s -f %f -a 3000000 -h %d -t 0 -n %d",
                                       _airspyPath.c_str(),
-                                      logDir.c_str(),
-                                      _rawCaptureCount,
-                                      frequencyMhz,
-                                      rawCapture.gain,
+                                      captureDataPath.c_str(),
+                                      tuneFreqMhz,
+                                      gain,
                                       numSamples);
             captureLogPath = formatString("%s/airspy-mini.%d.log", logDir.c_str(), _rawCaptureCount);
             sdrPathStatus = _sdrPathStatusText(deviceType, frequencyMhz);
             processName = "airspy-mini-capture";
+            sdrType = "airspy_mini";
             logInfo() << "COMMAND_ID_RAW_CAPTURE - using AirSpy Mini capture command";
+        }
+
+        // Write capture metadata JSON
+        {
+            auto now = std::chrono::system_clock::now();
+            auto epoch_s = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+            std::time_t tt = std::chrono::system_clock::to_time_t(now);
+            char timeBuf[64];
+            std::strftime(timeBuf, sizeof(timeBuf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&tt));
+
+            std::string metaPath = captureDataPath.substr(0, captureDataPath.size() - 4) + ".json";
+            std::ofstream metaFile(metaPath);
+            if (metaFile.is_open()) {
+                metaFile << "{\n";
+                metaFile << formatString("  \"sdr\": \"%s\",\n", sdrType.c_str());
+                metaFile << formatString("  \"requested_freq_mhz\": %.6f,\n", frequencyMhz);
+                metaFile << formatString("  \"tune_freq_mhz\": %.6f,\n", tuneFreqMhz);
+                metaFile << formatString("  \"dc_offset_hz\": %.0f,\n", dcOffsetHz);
+                metaFile << formatString("  \"sample_rate_hz\": %d,\n", sampleRate);
+                metaFile << formatString("  \"bandwidth_hz\": %d,\n", sampleRate);
+                metaFile << formatString("  \"duration_seconds\": %d,\n", sampleDurationSeconds);
+                metaFile << formatString("  \"gain\": %d,\n", gain);
+                metaFile << "  \"format\": \"complex_float32\",\n";
+                metaFile << formatString("  \"capture_utc\": \"%s\",\n", timeBuf);
+                metaFile << formatString("  \"capture_epoch\": %lld,\n", (long long)epoch_s);
+                metaFile << formatString("  \"data_file\": \"%s\"\n", captureDataPath.c_str());
+                metaFile << "}\n";
+                metaFile.close();
+                logInfo() << "COMMAND_ID_RAW_CAPTURE - metadata written to" << metaPath;
+            } else {
+                logError() << "COMMAND_ID_RAW_CAPTURE - failed to write metadata to" << metaPath;
+            }
         }
 
         _mavlink->sendStatusText(sdrPathStatus.c_str(), MAV_SEVERITY_INFO);

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -57,8 +57,16 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
         pulseInfo.confirmed_status  = 0;
         pulseInfo.noise_psd         = udpPulseInfo.noise_psd;
         pulseInfo.start_time_seconds = udpPulseInfo.start_time_seconds;
-        logDebug() << "NO DETECTION from Detector" << pulseInfo.tag_id
-                   << "noise_psd" << pulseInfo.noise_psd;
+
+        auto telemetry = _telemetryCache->telemetryForTime(udpPulseInfo.start_time_seconds);
+        logDebug() << formatString("NO DETECTION Id: %2u noise_psd: %5.1g freq: %9u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
+                                   pulseInfo.tag_id,
+                                   pulseInfo.noise_psd,
+                                   pulseInfo.frequency_hz,
+                                   telemetry.position.latitude,
+                                   telemetry.position.longitude,
+                                   telemetry.attitudeEuler.yawDegrees,
+                                   telemetry.position.relativeAltitude);
     } else {
         auto telemetry = _telemetryCache->telemetryForTime(udpPulseInfo.start_time_seconds);
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -389,19 +389,22 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         evt_threshold_cache: dict with 'threshold' key (or None to regenerate)
 
     Returns:
-        (detections, noise_psd) where:
+        (detections, noise_psd, best_candidate) where:
           detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score)
                       sorted by SNR descending.
           noise_psd:  float — median noise PSD across frequency bins when no
                       detections are found; None when detections are present;
                       NaN on early-exit error paths (insufficient data).
+          best_candidate: dict with keys (freq_hz, snr_db, score_ratio,
+                      noise_psd) for the strongest sub-threshold bin when
+                      no detections; None otherwise.
     """
     _, n_time = power.shape
 
     # Maximum valid first-pulse position
     max_start = n_time - (K - 1) * N
     if max_start <= 0:
-        return [], float('nan')
+        return [], float('nan'), None
     search_range = min(N, max_start)
 
     # Index matrix: (search_range, K) — each row is one candidate pattern
@@ -516,7 +519,16 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     if len(det_bins) == 0:
         # No detections — return median noise PSD so callers can report it
         median_noise_psd = float(np.median(noise_power) / psd_scale)
-        return [], median_noise_psd
+        # Best sub-threshold candidate for diagnostics
+        score_ratios = best_scores / np.maximum(threshold, 1e-30)
+        best_idx = int(np.argmax(score_ratios))
+        best_cand = {
+            'freq_hz': float(freq_axis[best_idx]),
+            'snr_db': float(10.0 * np.log10(best_scores[best_idx] / noise_power[best_idx])),
+            'score_ratio': float(score_ratios[best_idx]),
+            'noise_psd': float(noise_power[best_idx] / psd_scale),
+        }
+        return [], median_noise_psd, best_cand
 
     results = []
     for b in det_bins:
@@ -552,7 +564,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         if len(merged) >= 1:
             break
 
-    return merged, None
+    return merged, None, None
 
 
 # ---------------------------------------------------------------------------
@@ -651,7 +663,7 @@ def main():
     print(f'  PRI (N)         {N} STFT windows')
     print(f'  Freq bins       {nfft}  ({freq_res:.1f} Hz resolution, W matrix)')
     print(f'  Segment         {samples_needed} samples  ({seg_sec:.1f} s)')
-    print(f'  Pf              {args.pf:.0e}  '
+    print(f'  False alarm %   {args.pf * 100:.2g}%  '
           f'(~{fa_per_hour:.2f} false alarms/hour)')
     print(f'  UDP port        {args.port}')
     if args.center_freq > 0:
@@ -879,7 +891,7 @@ def main():
                 evt_threshold_cache['n_freq'] = n_freq_cur
                 evt_threshold_cache['n_time'] = n_time_cur
 
-            detections, nodet_noise_psd = fold_detect(
+            detections, nodet_noise_psd, best_candidate = fold_detect(
                                      power, N, args.pf, args.fs, nfft,
                                      n_w, n_ol, samples_needed,
                                      evt_threshold_cache, W=W, Wf=Wf,
@@ -979,8 +991,19 @@ def main():
                         confirmed_status=0,
                         noise_psd=nodet_noise_psd,
                     )
+                cand_str = ''
+                if best_candidate is not None:
+                    cand_freq = best_candidate['freq_hz']
+                    if args.center_freq > 0:
+                        cand_freq_str = f'{args.center_freq + cand_freq / 1e6:.6f} MHz'
+                    else:
+                        cand_freq_str = f'{cand_freq:+.1f} Hz'
+                    cand_str = (f'  best={cand_freq_str} '
+                                f'SNR {best_candidate["snr_db"]:.1f} dB '
+                                f'ratio {best_candidate["score_ratio"]:.3f} '
+                                f'noise {best_candidate["noise_psd"]:.3e}')
                 print(f'[{cycle:4d} {ts_str}]  no detection  '
-                      f'{proc_ms:.0f} ms{gap_flag}')
+                      f'{proc_ms:.0f} ms{gap_flag}{cand_str}')
 
     except KeyboardInterrupt:
         pass  # Handled by signal handler


### PR DESCRIPTION
## Changes

### Raw Capture
- Use `RawCaptureInfo_t.frequency_hz` from updated tunnel protocol when provided; fall back to first tag's frequency for backward compatibility
- Parse payload before spawning thread to avoid dangling `tunnel.payload` reference
- Write `.json` metadata file alongside each `.dat` capture (SDR type, requested/tune freq, DC offset, sample rate, bandwidth, gain, duration, format, UTC timestamp)
- Increase capture duration from 8s to 13s
- Update tunnel-protocol submodule to 315e491

### Logging Improvements
- Change Pf startup banner from scientific notation to percentage format (`False alarm %`)
- `fold_detect` now returns a 3-tuple with best sub-threshold candidate dict for no-detection diagnostics
- No-detection log line includes best candidate frequency, SNR, score ratio, and noise PSD
- PulseHandler no-detection log now includes telemetry lookup (lat/lon/yaw/alt) matching the detection log format