### PR TITLE
detector: configurable detection and confidence thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
 
   # ── Pulse detector validation ──────────────────────────────────────
   detector:
+    name: detector (${{ matrix.os }}, py${{ matrix.python-version }})
     strategy:
       fail-fast: false
       matrix:

--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -143,7 +143,7 @@ void CommandHandler::_startDetector(LogFileManager* logFileManager, const Tunnel
     _processes.push_back(detectorProc);
 }
 
-void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode)
+void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio)
 {
     int     secondaryChannelIncrement   = secondaryChannel ? 1 : 0;
     int     tagId                       = tagInfo.id + secondaryChannelIncrement;
@@ -162,12 +162,14 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
                                            " --tp %f --tip %f --fs %d --port %d"
                                            " --tag-id %d --freq %u --pulse-port %d"
                                            " --center-freq %f --pf %f"
+                                           " --detection-margin %f --confidence-ratio %f"
                                            " --threshold-cache-dir \"%s\"",
                                 pythonCmd.c_str(),
                                 repoDir.c_str(),
                                 tp, tip, sampleRate, portData,
                                 tagId, tagInfo.frequency_hz, kPulseUdpPort,
                                 centerFreqMhz, tagInfo.false_alarm_probability,
+                                detectionMargin, confidenceRatio,
                                 cacheDir.c_str());
 
     std::string root    = formatString("py_detector_%d", tagId);
@@ -227,6 +229,7 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
 
         logInfo() << "COMMAND_ID_START_DETECTION:";
         logInfo() << "\tradio_center_frequency_hz:" << startDetection.radio_center_frequency_hz;
+        logInfo() << "\tdetection_margin:" << startDetection.detection_margin << " confidence_ratio:" << startDetection.confidence_ratio;
         const double centerFrequencyMhz = (double)startDetection.radio_center_frequency_hz / 1000000.0;
 
         std::string sdrPathStatus;
@@ -367,11 +370,24 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
 
         bool isHFMode = (deviceType == AirSpyDeviceType::HF || deviceType == AirSpyDeviceType::SIMULATOR);
 
+        // Python detector thresholds — use defaults if not set (0 means use default)
+        double detectionMargin = startDetection.detection_margin > 0 ? startDetection.detection_margin : 0.90;
+        double confidenceRatio = startDetection.confidence_ratio > 0 ? startDetection.confidence_ratio : 1.3;
+        if (startDetection.detection_margin < 0) {
+            logError() << "Negative detection_margin (" << startDetection.detection_margin << "), using default:" << detectionMargin;
+        }
+        if (startDetection.confidence_ratio < 0) {
+            logError() << "Negative confidence_ratio (" << startDetection.confidence_ratio << "), using default:" << confidenceRatio;
+        }
+        if (startDetection.detection_mode == DETECTION_MODE_PYTHON) {
+            logInfo() << "Python detector thresholds: detectionMargin:" << detectionMargin << " confidenceRatio:" << confidenceRatio;
+        }
+
         for (const TunnelProtocol::TagInfo_t& tagInfo: _tagDatabase) {
             if (startDetection.detection_mode == DETECTION_MODE_PYTHON) {
-                _startPythonDetector(logFileManager, tagInfo, false /* secondaryChannel */, isHFMode);
+                _startPythonDetector(logFileManager, tagInfo, false /* secondaryChannel */, isHFMode, detectionMargin, confidenceRatio);
                 if (tagInfo.intra_pulse2_msecs != 0) {
-                    _startPythonDetector(logFileManager, tagInfo, true /* secondaryChannel */, isHFMode);
+                    _startPythonDetector(logFileManager, tagInfo, true /* secondaryChannel */, isHFMode, detectionMargin, confidenceRatio);
                 }
             } else {
                 _startDetector(logFileManager, tagInfo, false /* secondaryChannel */);

--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -38,7 +38,7 @@ private:
     bool _handleCleanLogs       (void);
     void _handleTunnelMessage   (const mavlink_message_t& message);
     void _startDetector         (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel);
-    void _startPythonDetector   (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode);
+    void _startPythonDetector   (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio);
     AirSpyDeviceType _connectedAirSpyType(std::string* errorMessage = nullptr);
     std::string _sdrPathStatusText(AirSpyDeviceType deviceType, double frequencyMhz) const;
     std::string _checkForAirSpy  (void);

--- a/detector/FREQUENCY_RANGE.md
+++ b/detector/FREQUENCY_RANGE.md
@@ -1,0 +1,61 @@
+# Frequency Detection Range
+
+## DC Spike Avoidance
+
+The Airspy HF+ has a hardware DC spur at its tuned center frequency. The pipeline avoids this with a two-stage offset:
+
+1. **Radio tuning**: The HF+ is tuned **+10 kHz above** the requested center frequency (`kAirSpyHfFrequencyOffsetHz = 10000` in `CommandHandler.h`).
+2. **Decimator shift**: The decimator applies `--shift-khz 10` to digitally shift the signal back, re-centering the target at DC while pushing the hardware DC spike to +10 kHz — well outside the ~3.8 kHz decimated bandwidth.
+
+The Airspy Mini does **not** apply this offset — it tunes to the exact requested frequency.
+
+## Detection Bandwidth
+
+The detector searches all frequency bins across the full decimated bandwidth. The maximum detectable offset from the tuned center frequency is ±Fs/2:
+
+| Radio | Decimated Fs | Detection range |
+|-------|-------------|-----------------|
+| HF+   | 3840 Hz     | ±1920 Hz        |
+| Mini   | 3750 Hz     | ±1875 Hz        |
+
+Signals near the band edges will be attenuated by the decimation FIR filter roll-off, reducing detection sensitivity.
+
+## Frequency Resolution
+
+The detector uses a spectral weighting matrix with sub-bin shifts (zetas = [0.0, 0.5]), doubling the effective frequency resolution compared to a plain FFT. The number of output frequency bins is `nfft = 2 × n_w`, where `n_w = ceil(tp × Fs)`.
+
+| Pulse width (tp) | Fs (Hz) | n_w (samples) | nfft (bins) | Resolution (Hz/bin) |
+|-------------------|---------|---------------|-------------|---------------------|
+| 15 ms             | 3840    | 58            | 116         | ~33 Hz              |
+| 20 ms             | 3840    | 77            | 154         | ~25 Hz              |
+| 15 ms             | 3750    | 57            | 114         | ~33 Hz              |
+| 20 ms             | 3750    | 75            | 150         | ~25 Hz              |
+
+## Pipeline Paths
+
+Both radio types produce identical UDP packets at the detector input — the ZMQ vs pipe distinction is entirely upstream:
+
+```
+HF+:   airspyhf_zeromq_rx → [ZMQ] → airspyhf_decimator → [UDP] → pulse_detector.py
+Mini:  airspy_rx → [pipe] → csdr-uavrt → [pipe] → airspy_channelize → [UDP] → pulse_detector.py
+```
+
+### UDP Packet Format (both paths)
+
+| Offset | Size | Content |
+|--------|------|---------|
+| 0      | 8 B  | Timestamp: `complex<float>` — real = uint32 seconds (bit-cast to float32), imag = uint32 nanoseconds (bit-cast to float32) |
+| 8      | N×8 B | IQ samples: `complex64` (float32 I + float32 Q per sample) |
+
+### Differences at Detector Input
+
+| Parameter | HF+ | Mini |
+|-----------|-----|------|
+| `--fs`    | 3840 | 3750 |
+| `--port`  | 10000+ | 20000+ |
+
+## Raw Captures
+
+Raw IQ captures with the Airspy HF+ also include the +10 kHz tuning offset (no decimator compensation). The signal of interest appears at −10 kHz in the baseband spectrum. Post-processing must account for this offset.
+
+Airspy Mini raw captures tune to the exact requested frequency — no offset.

--- a/detector/MINI_VS_HF_COMPARISON.md
+++ b/detector/MINI_VS_HF_COMPARISON.md
@@ -1,0 +1,22 @@
+# Airspy Mini vs HF+: SNR, Noise Floor, and Frequency Stability
+
+Field data from back-to-back runs at 3 km range, 400 ft altitude (Apr 8 2026).
+
+- **Airspy Mini**: `airspy_rx` → `csdr-uavrt` (8× FIR) → `airspy_channelize` → UDP → **uavrt_detection** (C++ / MATLAB-compiled)
+- **Airspy HF+**: `airspyhf_zeromq_rx` → ZMQ → `airspyhf_decimator` (200×) → UDP → **pulse_detector.py** (Python)
+
+## SNR and Noise Floor
+
+| Metric | Airspy Mini (C++ detector) | Airspy HF+ (Python detector) |
+|---|---|---|
+| **Typical SNR** | 10–23 dB (high variance) | 14–28 dB (higher, more stable) |
+| **Peak SNR** | ~24 dB | ~28 dB |
+| **Noise PSD** | 7e-09 to 3e-08 | 2e-14 to 5e-12 |
+| **stft_score** | 0.001 – 0.4 | 1e-12 to 1e-09 |
+
+The HF noise floor is ~4 orders of magnitude lower (picoWatts vs nanoWatts). The HF+ has superior dynamic range and the ZMQ→decimator path preserves 32-bit float precision. The stft_score values are correspondingly much smaller in absolute terms (but detection still works because the threshold is proportional to the per-bin noise power).
+
+## Frequency Stability
+
+- **Mini / C++ detector**: The detected frequency drifts across bins — `146168257` to `146171414`, a spread of ~3 kHz. The C++ detector uses `freqSearchHardLock` mode but still wanders across frequency bins between segments.
+- **HF+ / Python detector**: Locks to `146170265` (or `146170232`) Hz and stays there. Two closely-spaced bins with only 33 Hz separation. Much tighter lock.

--- a/detector/README.md
+++ b/detector/README.md
@@ -141,8 +141,8 @@ Defined in `TunnelProtocol.h` and mirrored in the detector:
 
 | Value | Name | Meaning |
 |-------|------|------|
-| `0` | SUBTHRESHOLD | Marginal detection (fold score < 2× threshold) |
-| `1` | SUPERTHRESHOLD | Confident detection (fold score ≥ 2× threshold) |
+| `0` | SUBTHRESHOLD | Marginal detection (fold score < confidence_ratio × threshold) |
+| `1` | SUPERTHRESHOLD | Confident detection (fold score ≥ confidence_ratio × threshold) |
 | `2` | CONFIRMED | Reserved for stateful detectors (uavrt_detection); **never sent by pulse_detector.py** |
 | `3` | NO_DETECTION | Detector searched this cycle and found nothing |
 
@@ -150,7 +150,7 @@ Defined in `TunnelProtocol.h` and mirrored in the detector:
 
 Binary (0 or 1). Since the Python detector is stateless (no cross-cycle confirmation), it uses the confidence ratio as a proxy:
 
-- `confirmed_status=1` — confident detection (score ≥ 2× threshold)
+- `confirmed_status=1` — confident detection (score ≥ confidence_ratio × threshold; default ratio 1.3)
 - `confirmed_status=0` — everything else (marginal, no detection, heartbeat)
 
 The controller logs `confirmed_status=1` pulses at Info level and `confirmed_status=0` at Debug level. Both are forwarded to the GCS.
@@ -159,8 +159,8 @@ The controller logs `confirmed_status=1` pulses at Info level and `confirmed_sta
 
 | Scenario | `detection_status` | `confirmed_status` | Key fields |
 |----------|-------------------|--------------------|-----------|
-| **Strong detection** (score ≥ 2× threshold) | `1` (SUPERTHRESHOLD) | `1` | frequency, SNR, noise_psd, stft_score |
-| **Marginal detection** (score < 2× threshold) | `0` (SUBTHRESHOLD) | `0` | frequency, SNR, noise_psd, stft_score |
+| **Strong detection** (score ≥ confidence_ratio × threshold) | `1` (SUPERTHRESHOLD) | `1` | frequency, SNR, noise_psd, stft_score |
+| **Marginal detection** (score < confidence_ratio × threshold) | `0` (SUBTHRESHOLD) | `0` | frequency, SNR, noise_psd, stft_score |
 | **No detection** | `3` (NO_DETECTION) | `0` | noise_psd, start_time (no frequency/SNR) |
 | **Heartbeat** (periodic keepalive) | `0` | `0` | frequency_hz=0 (controller recognises as heartbeat) |
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -377,7 +377,8 @@ def save_evt_cache(cache_dir, N, K, mu, sigma, n_trials=100):
 # ---------------------------------------------------------------------------
 
 def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
-                evt_threshold_cache, W=None, Wf=None, debug=False):
+                evt_threshold_cache, W=None, Wf=None, debug=False,
+                detection_margin=0.90):
     """Fold power spectrogram at PRI and detect pulses.
 
     With tipu=0, tipj=0 the only free parameter is the first-pulse offset
@@ -390,8 +391,8 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
 
     Returns:
         (detections, noise_psd, best_candidate) where:
-          detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score)
-                      sorted by SNR descending.
+          detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score,
+                      score_ratio) sorted by SNR descending.
           noise_psd:  float — median noise PSD across frequency bins when no
                       detections are found; None when detections are present;
                       NaN on early-exit error paths (insufficient data).
@@ -478,11 +479,20 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
                 print(f'ERROR: Insufficient data for EVT threshold. '
                       f'Segment length ({n_time} samples) too short for K={K} folds.',
                       flush=True)
-                return [], float('nan')
+                return [], float('nan'), None
             save_evt_cache(cache_dir, N, K, mu, sigma)
         evt_threshold_cache['threshold'] = base_threshold
     else:
         base_threshold = evt_threshold_cache['threshold']
+
+    # Apply detection margin to lower the EVT threshold, increasing
+    # sensitivity at the cost of more near-threshold (marginal) detections.
+    # The two-tier confidence system classifies these via confidence_ratio.
+    base_threshold *= detection_margin
+    if detection_margin != 1.0 and not evt_threshold_cache.get('margin_logged'):
+        print(f'  [Detection margin={detection_margin:.2f} applied: '
+              f'effective threshold={base_threshold:.4e}]', flush=True)
+        evt_threshold_cache['margin_logged'] = True
 
     # Scale threshold by per-bin noise power (frequency-dependent)
     threshold = base_threshold * noise_power
@@ -600,6 +610,10 @@ def main():
                     help='UDP port to send detected pulses to (0 = disabled)')
     ap.add_argument('--threshold-cache-dir', type=str, default=None,
                     help='Directory for EVT threshold cache files (default: no disk cache)')
+    ap.add_argument('--detection-margin', type=float, default=0.90,
+                    help='EVT threshold multiplier, lower = more sensitive (default: 0.90)')
+    ap.add_argument('--confidence-ratio', type=float, default=1.3,
+                    help='Score/threshold ratio for confirmed status (default: 1.3)')
     args = ap.parse_args()
 
     # --- Validate parameters ---
@@ -613,6 +627,10 @@ def main():
         sys.exit(f'Error: --tip (inter-pulse interval) must be positive, got {args.tip}')
     if args.fs <= 0:
         sys.exit(f'Error: --fs (sample rate) must be positive, got {args.fs}')
+    if args.detection_margin <= 0:
+        sys.exit(f'Error: --detection-margin must be positive, got {args.detection_margin}')
+    if args.confidence_ratio <= 0:
+        sys.exit(f'Error: --confidence-ratio must be positive, got {args.confidence_ratio}')
 
     # --- STFT geometry ---
     n_w  = int(np.ceil(args.tp * args.fs))
@@ -888,6 +906,7 @@ def main():
             if (evt_threshold_cache.get('n_freq') != n_freq_cur or
                 evt_threshold_cache.get('n_time') != n_time_cur):
                 evt_threshold_cache['threshold'] = None
+                evt_threshold_cache['margin_logged'] = False
                 evt_threshold_cache['n_freq'] = n_freq_cur
                 evt_threshold_cache['n_time'] = n_time_cur
 
@@ -895,7 +914,8 @@ def main():
                                      power, N, args.pf, args.fs, nfft,
                                      n_w, n_ol, samples_needed,
                                      evt_threshold_cache, W=W, Wf=Wf,
-                                     debug=args.debug)
+                                     debug=args.debug,
+                                     detection_margin=args.detection_margin)
             proc_ms = (time.monotonic() - t0) * 1000.0
 
             # Timestamp string (UTC) for the start of this segment
@@ -911,6 +931,8 @@ def main():
             # Append gap warning to output if segment had discontinuities
             gap_flag = ' [ZEROFILLED]' if had_gap else ''
 
+            confidence_ratio = args.confidence_ratio
+
             if detections:
                 det_total += len(detections)
 
@@ -922,13 +944,12 @@ def main():
                 if current_ts is not None:
                     last_detection_ts = current_ts
 
-                # Score/threshold ratio < 2.0 indicates a marginal detection
-                # that is more likely to be a false alarm.  Report these as
-                # SUBTHRESHOLD so the GCS can display them differently.
-                CONFIDENCE_RATIO = 2.0
+                # Score/threshold ratio < confidence_ratio indicates a marginal
+                # detection that is more likely to be a false alarm.  Report
+                # these as SUBTHRESHOLD so the GCS can display them differently.
 
                 for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio in detections:
-                    is_marginal = score_ratio < CONFIDENCE_RATIO
+                    is_marginal = score_ratio < confidence_ratio
                     det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
                                   else DETECTION_STATUS_SUPERTHRESHOLD)
                     confidence_flag = '  [LOW]' if is_marginal else ''


### PR DESCRIPTION
Based on field testing at 3 km and 5 km with HF+ Python detector.

## Threshold Tuning (hardcoded defaults)

- **CONFIDENCE_RATIO**: 2.0 → 1.3 — reduces minimum confirmed SNR from ~16.5 dB to ~14.2 dB
- **DETECTION_MARGIN**: 0.90 applied to EVT base threshold — lowers minimum detectable SNR from ~13.5 dB to ~13.0 dB

## Runtime Configurability (QGC → controller → detector)

- Add `detection_margin` and `confidence_ratio` to `StartDetectionInfo_t` (tunnel-protocol submodule)
- Add `--detection-margin` and `--confidence-ratio` CLI args to `pulse_detector.py`
- Controller extracts values from tunnel protocol, defaults `0 → 0.90/1.3`
- Log raw struct values, resolved defaults, and per-detector command lines

## Rationale

Field-verified real signals at 12–15 dB SNR (confirmed by directional null when pointed away from collar at 5 km) were being either missed or marked `[LOW]`/`Conf:0`. The previous CONFIDENCE_RATIO of 2.0 required ~16.5 dB for confirmation, discarding ~4.5 dB of usable detection range.

The two-tier system is preserved: EVT threshold controls detection, CONFIDENCE_RATIO separates confirmed from marginal.

| Tier | Old | New |
|---|---|---|
| Detection threshold | ~13.5 dB | ~13.0 dB |
| Confidence threshold | ~16.5 dB | ~14.2 dB |

Existing EVT cache files remain valid — the margin is applied after cache load.

## Other Changes

- Log margin-adjusted threshold after EVT cache load
- Update README.md confidence docs (`2×` → configurable ratio)
- Fix AirSpy HF/HF+ naming inconsistency in comparison doc
- Field comparison notes (Mini/uavrt vs HF/Python) from Apr 8 flight testing