### PR TITLE
fix: cleanLocalLogs error check on fs::remove_all return value

### DIFF
--- a/controller/LogFileManager.cpp
+++ b/controller/LogFileManager.cpp
@@ -227,7 +227,8 @@ void LogFileManager::cleanLocalLogs()
         fs::path dirPath = _homeDir + "/" + logDir;
         std::error_code errorCode;
         logInfo() << "Removing directory " << dirPath;
-        if (!fs::remove_all(dirPath, errorCode)) {
+        fs::remove_all(dirPath, errorCode);
+        if (errorCode) {
             logError() << "Failed to remove directory " << dirPath << ": " << errorCode.message();
             MavlinkSystem::instance()->sendStatusText("#Error during log delete", MAV_SEVERITY_ERROR);
         }


### PR DESCRIPTION
fs::remove_all() returns std::uintmax_t (count of removed items), not bool. The previous code checked the return value as a bool, which silently swallowed errors: on failure remove_all returns (uintmax_t)-1 (non-zero), so the negated check was always false.

Check errorCode after the call instead, matching the pattern already used in pruneOnDiskPressure().