### PR TITLE
Add score_ratio repurposing and per-fold diagnostics

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -400,6 +400,7 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
         std::string startedStr = formatString("All processes started at center hz: %.3f", (double)startDetection.radio_center_frequency_hz / 1000000.0);
         _mavlink->sendStatusText(startedStr.c_str(), MAV_SEVERITY_INFO);
 
+        _mavlink->setDetectionMode(startDetection.detection_mode);
         _mavlink->setHeartbeatStatus(HEARTBEAT_STATUS_DETECTING);
     }).detach();
 
@@ -424,6 +425,7 @@ bool CommandHandler::_handleStopDetection(void)
         delete _airspyPipe;
         _airspyPipe = NULL;
 
+        _mavlink->setDetectionMode(DETECTION_MODE_UAVRT);
         _mavlink->setHeartbeatStatus(HEARTBEAT_STATUS_HAS_TAGS);
 
         auto logFileManager = LogFileManager::instance();

--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -383,6 +383,8 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
             logInfo() << "Python detector thresholds: detectionMargin:" << detectionMargin << " confidenceRatio:" << confidenceRatio;
         }
 
+        _mavlink->setDetectionMode(startDetection.detection_mode);
+
         for (const TunnelProtocol::TagInfo_t& tagInfo: _tagDatabase) {
             if (startDetection.detection_mode == DETECTION_MODE_PYTHON) {
                 _startPythonDetector(logFileManager, tagInfo, false /* secondaryChannel */, isHFMode, detectionMargin, confidenceRatio);
@@ -400,7 +402,6 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
         std::string startedStr = formatString("All processes started at center hz: %.3f", (double)startDetection.radio_center_frequency_hz / 1000000.0);
         _mavlink->sendStatusText(startedStr.c_str(), MAV_SEVERITY_INFO);
 
-        _mavlink->setDetectionMode(startDetection.detection_mode);
         _mavlink->setHeartbeatStatus(HEARTBEAT_STATUS_DETECTING);
     }).detach();
 

--- a/controller/MavlinkSystem.h
+++ b/controller/MavlinkSystem.h
@@ -48,6 +48,8 @@ public:
 	Telemetry& 					telemetry					() { return _telemetry; }
 	uint16_t 					heartbeatStatus				() const { return _heartbeatStatus.load(); }
 	void						setHeartbeatStatus			(uint16_t heartbeatStatus) { _heartbeatStatus.store(heartbeatStatus); }
+	uint32_t					detectionMode				() const { return _detectionMode.load(); }
+	void						setDetectionMode			(uint32_t mode) { _detectionMode.store(mode); }
 
 private:
 	MavlinkSystem();
@@ -64,6 +66,7 @@ private:
 	std::mutex 					_subscriptions_mutex {};
 	Telemetry 					_telemetry;
 	std::atomic<uint16_t>		_heartbeatStatus { HEARTBEAT_STATUS_IDLE };
+	std::atomic<uint32_t>		_detectionMode { DETECTION_MODE_UAVRT };
 
 	friend class MavlinkOutgoingMessageQueue;
 };

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -101,7 +101,22 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
             }
         }
 
-        std::string pulseStatus = formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f stft_score: %5.1g noise_psd: %5.1g freq: %9u seq: %u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
+        bool isPythonDetector = (_mavlink->detectionMode() == DETECTION_MODE_PYTHON);
+        std::string pulseStatus = isPythonDetector
+            ? formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f score_ratio: %.3f noise_psd: %5.1g freq: %9u seq: %u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
+                                        pulseInfo.confirmed_status,
+                                        pulseInfo.tag_id,
+                                        pulseInfo.snr,
+                                        pulseInfo.orientation_z,
+                                        pulseInfo.stft_score,
+                                        pulseInfo.noise_psd,
+                                        pulseInfo.frequency_hz,
+                                        pulseInfo.group_seq_counter,
+                                        telemetry.position.latitude,
+                                        telemetry.position.longitude,
+                                        telemetry.attitudeEuler.yawDegrees,
+                                        telemetry.position.relativeAltitude)
+            : formatString("Conf: %u Id: %2u snr: %5.1f heading: %3.1f stft_score: %5.1g noise_psd: %5.1g freq: %9u seq: %u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
                                         pulseInfo.confirmed_status,
                                         pulseInfo.tag_id,
                                         pulseInfo.snr,

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -392,7 +392,9 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     Returns:
         (detections, noise_psd, best_candidate) where:
           detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score,
-                      score_ratio) sorted by SNR descending.
+                      score_ratio, fold_info) sorted by SNR descending.
+                      fold_info is a dict with 'uniformity' (float) and
+                      'fold_snrs' (list of per-fold SNRs in dB).
           noise_psd:  float — median noise PSD across frequency bins when no
                       detections are found; None when detections are present;
                       NaN on early-exit error paths (insufficient data).
@@ -551,9 +553,16 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         # Score-to-threshold ratio: how far above threshold this detection is.
         # Values near 1.0 are marginal (likely false alarm); >>1 is confident.
         score_ratio = float(best_scores[b] / max(threshold[b], 1e-30))
+        # Per-fold diagnostics: individual on-window powers and SNRs
+        t0 = int(best_offsets[b])
+        on_idx = t0 + np.arange(K) * N
+        on_powers = power[b, on_idx]
+        fold_snrs_db = (10.0 * np.log10(on_powers / noise_power[b])).tolist()
+        uniformity = float(on_powers.min() / max(on_powers.max(), 1e-30))
+        fold_info = {'uniformity': uniformity, 'fold_snrs': fold_snrs_db}
         results.append((freq_axis[b], snr_db, int(best_offsets[b]),
                          float(noise_power[b] / psd_scale), stft_score,
-                         score_ratio))
+                         score_ratio, fold_info))
 
     results.sort(key=lambda x: -x[1])
 
@@ -564,11 +573,11 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     min_sep = max(15, nfft // 4)
     merged = []
     used_bins = []
-    for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio in results:
+    for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info in results:
         b = int(np.argmin(np.abs(freq_axis - freq_hz)))
         if any(abs(b - ub) <= min_sep for ub in used_bins):
             continue
-        merged.append((freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio))
+        merged.append((freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info))
         used_bins.append(b)
         # Report only the strongest detection
         if len(merged) >= 1:
@@ -683,6 +692,8 @@ def main():
     print(f'  Segment         {samples_needed} samples  ({seg_sec:.1f} s)')
     print(f'  False alarm %   {args.pf * 100:.2g}%  '
           f'(~{fa_per_hour:.2f} false alarms/hour)')
+    print(f'  Det margin      {args.detection_margin:.2f}')
+    print(f'  Conf ratio      {args.confidence_ratio:.2f}')
     print(f'  UDP port        {args.port}')
     if args.center_freq > 0:
         print(f'  Center freq     {args.center_freq:.6f} MHz')
@@ -948,7 +959,7 @@ def main():
                 # detection that is more likely to be a false alarm.  Report
                 # these as SUBTHRESHOLD so the GCS can display them differently.
 
-                for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio in detections:
+                for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info in detections:
                     is_marginal = score_ratio < confidence_ratio
                     det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
                                   else DETECTION_STATUS_SUPERTHRESHOLD)
@@ -967,7 +978,7 @@ def main():
                             start_time_seconds=start_time_s,
                             predict_next_start_seconds=predict_next_s,
                             snr=snr_db,
-                            stft_score=stft_score,
+                            stft_score=score_ratio,
                             group_seq_counter=cycle,
                             group_ind=0,
                             group_snr=snr_db,
@@ -982,14 +993,20 @@ def main():
                               f'{abs_mhz:.6f} MHz  '
                               f'({freq_hz:+.1f} Hz)  '
                               f'SNR {snr_db:.1f} dB  '
+                              f'score_ratio {score_ratio:.3f}  '
                               f'noise {noise_psd:.3e}  '
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}{confidence_flag}')
                     else:
                         print(f'[{cycle:4d} {ts_str}]  DETECTED  '
                               f'{freq_hz:+.1f} Hz  '
                               f'SNR {snr_db:.1f} dB  '
+                              f'score_ratio {score_ratio:.3f}  '
                               f'noise {noise_psd:.3e}  '
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}{confidence_flag}')
+                    fold_snrs_str = ', '.join(f'{s:.1f}' for s in fold_info['fold_snrs'])
+                    print(f'  [FOLDS] score_ratio={score_ratio:.3f}  '
+                          f'uniformity={fold_info["uniformity"]:.3f}  '
+                          f'per_fold_snr=[{fold_snrs_str}] dB')
             else:
                 # Send a no-detection report so the controller/GCS knows
                 # we searched this cycle and found nothing.  Uses
@@ -997,6 +1014,7 @@ def main():
                 # status value that cannot be confused with a real pulse.
                 if pulse_sock is not None and args.freq:
                     start_time_s = current_ts / 1e9 if current_ts else time.time()
+                    nodet_score_ratio = best_candidate['score_ratio'] if best_candidate is not None else 0.0
                     send_pulse_udp(
                         pulse_sock, pulse_dest,
                         tag_id=args.tag_id,
@@ -1004,7 +1022,7 @@ def main():
                         start_time_seconds=start_time_s,
                         predict_next_start_seconds=0.0,
                         snr=0.0,
-                        stft_score=0.0,
+                        stft_score=nodet_score_ratio,
                         group_seq_counter=cycle,
                         group_ind=0,
                         group_snr=0.0,


### PR DESCRIPTION
## Changes

- **score_ratio in stft_score slot**: Python detector now sends `score_ratio` (fold_score / EVT_threshold) in the `stft_score` UDP field instead of the raw fold score. No wire format changes — just repurposes the field value.

- **Detection mode awareness**: PulseHandler now knows which detector type is active via `MavlinkSystem::detectionMode()`. Controller logs label the field as `score_ratio` (Python) or `stft_score` (C++ detector) accordingly.

- **Per-fold diagnostics**: Each detection now logs a `[FOLDS]` line with:
  - `uniformity`: min(on_powers)/max(on_powers) — 1.0 = perfectly uniform across K=5 folds
  - `per_fold_snr`: individual SNR (dB) for each of the 5 on-windows

- **Python log header**: Added `Det margin` and `Conf ratio` to the startup header section.

## Files changed

| File | Change |
|------|--------|
| `controller/MavlinkSystem.h` | Added `detectionMode()`/`setDetectionMode()` accessor + atomic member |
| `controller/CommandHandler.cpp` | Set/reset detection mode on start/stop detection |
| `controller/PulseHandler.cpp` | Conditional log label based on detection mode |
| `detector/pulse_detector.py` | score_ratio repurposing, fold diagnostics, header additions |

## Purpose

Provides normalized detection confidence (score_ratio) to GCS and per-fold diagnostic data for evaluating cross-rate rejection thresholds at long range.