### PR TITLE
Configurable K, fractional PRI fix, --debug-detector flag

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -158,7 +158,7 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
     // Default to 5 if the GCS sends 0 or 1 (unset or invalid).
     uint32_t k = tagInfo.k >= 2 ? tagInfo.k : 5;
     if (tagInfo.k < 2) {
-        logWarn() << "Tag" << tagId << "has invalid k=" << tagInfo.k << ", defaulting to 5";
+        logWarn() << "Tag " << tagId << " has invalid k=" << tagInfo.k << ", defaulting to 5";
     }
 
     std::string repoDir     = formatString("%s/repos/MavlinkTagController2", _homePath);

--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -154,6 +154,13 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
     double  tp                          = tagInfo.pulse_width_msecs / 1000.0;
     double  centerFreqMhz              = double(tagInfo.channelizer_channel_center_frequency_hz) / 1000000.0;
 
+    // Validate K (fold count): must be >= 2 for meaningful integration.
+    // Default to 5 if the GCS sends 0 or 1 (unset or invalid).
+    uint32_t k = tagInfo.k >= 2 ? tagInfo.k : 5;
+    if (tagInfo.k < 2) {
+        logWarn() << "Tag" << tagId << "has invalid k=" << tagInfo.k << ", defaulting to 5";
+    }
+
     std::string repoDir     = formatString("%s/repos/MavlinkTagController2", _homePath);
     std::string venvPython  = formatString("%s/.venv/bin/python3", repoDir.c_str());
     std::string pythonCmd   = (access(venvPython.c_str(), X_OK) == 0) ? venvPython : std::string("python3");
@@ -173,7 +180,7 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
                                 centerFreqMhz, tagInfo.false_alarm_probability,
                                 detectionMargin, confidenceRatio,
                                 cacheDir.c_str(),
-                                tagInfo.k);
+                                k);
     if (_debugDetector) {
         commandStr += " --debug";
     }

--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -25,11 +25,12 @@
 
 using namespace TunnelProtocol;
 
-CommandHandler::CommandHandler(MavlinkSystem* mavlink, bool simulatorMode, const std::string& simulatorPreset)
+CommandHandler::CommandHandler(MavlinkSystem* mavlink, bool simulatorMode, const std::string& simulatorPreset, bool debugDetector)
     : _mavlink          (mavlink)
     , _homePath         (getenv("HOME"))
     , _simulatorMode    (simulatorMode)
     , _simulatorPreset  (simulatorPreset)
+    , _debugDetector    (debugDetector)
 {
     if (strcmp(_homePath, "/home/pi") == 0) {
         // When we are running from a crontab entry on the rPi the PATH environment variable is not fully set yet.
@@ -163,14 +164,19 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
                                            " --tag-id %d --freq %u --pulse-port %d"
                                            " --center-freq %f --pf %f"
                                            " --detection-margin %f --confidence-ratio %f"
-                                           " --threshold-cache-dir \"%s\"",
+                                           " --threshold-cache-dir \"%s\""
+                                           " --k %u",
                                 pythonCmd.c_str(),
                                 repoDir.c_str(),
                                 tp, tip, sampleRate, portData,
                                 tagId, tagInfo.frequency_hz, kPulseUdpPort,
                                 centerFreqMhz, tagInfo.false_alarm_probability,
                                 detectionMargin, confidenceRatio,
-                                cacheDir.c_str());
+                                cacheDir.c_str(),
+                                tagInfo.k);
+    if (_debugDetector) {
+        commandStr += " --debug";
+    }
 
     std::string root    = formatString("py_detector_%d", tagId);
     std::string logPath = logFileManager->filename(LogFileManager::DETECTORS, root.c_str(), "log");

--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -14,7 +14,7 @@ class LogFileManager;
 
 class CommandHandler {
 public:
-    explicit CommandHandler(MavlinkSystem* mavlink, bool simulatorMode = false, const std::string& simulatorPreset = "strong");
+    explicit CommandHandler(MavlinkSystem* mavlink, bool simulatorMode = false, const std::string& simulatorPreset = "strong", bool debugDetector = false);
 
     static constexpr int kPulseUdpPort = 50000; // UDP port for pulse/heartbeat reports from detectors
 
@@ -58,6 +58,7 @@ private:
     int                            _rawCaptureCount         = 0;
     bool                            _simulatorMode          = false;
     std::string                     _simulatorPreset;
+    bool                            _debugDetector          = false;
 
     static constexpr int kAirSpyHfFrequencyOffsetHz = 10000; // 10 kHz - takes into account 768 ksps incoming and 3840 Hz outgoing
 };

--- a/controller/PulseHandler.cpp
+++ b/controller/PulseHandler.cpp
@@ -59,8 +59,9 @@ void PulseHandler::handlePulse(const PulseHandler::UDPPulseInfo_T& udpPulseInfo)
         pulseInfo.start_time_seconds = udpPulseInfo.start_time_seconds;
 
         auto telemetry = _telemetryCache->telemetryForTime(udpPulseInfo.start_time_seconds);
-        logDebug() << formatString("NO DETECTION Id: %2u noise_psd: %5.1g freq: %9u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
+        logDebug() << formatString("NO DETECTION Id: %2u score_ratio: %.3f noise_psd: %5.1g freq: %9u lat/lon/yaw/alt: %3.6f %3.6f %4.0f %3.0f",
                                    pulseInfo.tag_id,
+                                   udpPulseInfo.stft_score,
                                    pulseInfo.noise_psd,
                                    pulseInfo.frequency_hz,
                                    telemetry.position.latitude,

--- a/controller/main.cpp
+++ b/controller/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
     bool        simulatorMode = false;
     std::string simulatorPreset = "strong";
 	std::string simulatorTelemetryEndpoint = "tcp://127.0.0.1:6001";
+    bool        debugDetector = false;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--simulator") == 0) {
@@ -51,6 +52,8 @@ int main(int argc, char** argv)
 			if (i + 1 < argc) {
 				simulatorTelemetryEndpoint = argv[++i];
 			}
+        } else if (strcmp(argv[i], "--debug-detector") == 0) {
+            debugDetector = true;
         } else {
             // Treat any other argument as the connection URL
             connectionUrl = argv[i];
@@ -83,7 +86,7 @@ int main(int argc, char** argv)
 
 	globalMavlinkSystem		= mavlink;
 
-    auto commandHandler 	= CommandHandler { mavlink, simulatorMode, simulatorPreset };
+    auto commandHandler 	= CommandHandler { mavlink, simulatorMode, simulatorPreset, debugDetector };
 
     udpPulseReceiver.start();
 

--- a/detector/README.md
+++ b/detector/README.md
@@ -15,7 +15,7 @@ airspyhf_zeromq_rx  →  ZMQ PUB  →  decimator  →  UDP  →  pulse_detector.
 
 ### 1. Data Accumulation (~10 seconds per cycle)
 
-The detector accumulates IQ samples until it has enough data to fold K=5 pulses:
+The detector accumulates IQ samples until it has enough data to fold K pulses (K is configurable via `--k`, default 5):
 
 ```
 samples_needed = STFT_step × (K × PRI_windows + 1) + STFT_overlap
@@ -63,7 +63,7 @@ For each frequency bin, the detector searches all possible first-pulse offsets w
 
 ```python
 search_range = min(PRI_windows, max_valid_start)
-pulse_idx = first_offset + [0, N, 2N, 3N, 4N]  # K=5 folds
+pulse_idx = first_offset + [0, N, 2N, ..., (K-1)×N]  # K folds
 ```
 
 **Folding operation:** Sum power at each candidate pattern:
@@ -127,7 +127,7 @@ noise  = noise_power[f]          # per-window noise estimate
 SNR_dB = 10 × log10(signal / noise)
 ```
 
-This matches uavrt_detection's convention: the fold score naturally scales with K (more folds → higher numerator → higher reported SNR). Expect roughly `10×log10(K)` dB improvement over single-pulse detection (≈ 7 dB for K=5).
+This matches uavrt_detection's convention: the fold score naturally scales with K (more folds → higher numerator → higher reported SNR). Expect roughly `10×log10(K)` dB improvement over single-pulse detection (e.g. ≈ 7 dB for K=5, ≈ 13 dB for K=20).
 
 > **Note:** The denominator is the single-window noise estimate, *not* `K × noise_power`. This means the reported SNR includes the integration gain and is directly comparable to uavrt_detection's output.
 
@@ -413,7 +413,7 @@ At 3840 Hz decimated rate with default parameters:
 
 ### False Alarm Rate
 
-With `--pf 5e-2` (default, Aggressive) and ~10-second cycles (K=5, tip=2.0s):
+With `--pf 5e-2` (default, Aggressive) and ~10-second cycles (K=5, tip=2.0 s):
 
 ```
 FA_rate = (3600 s/hour) / (10 s/cycle) × 5e-2 = 18 FA/hour
@@ -481,15 +481,15 @@ pip3 install numpy scipy
 
 ## Implementation Notes
 
-### Why K=5 (not K=10 as originally)?
+### Choosing K
 
-The code was simplified from K=10 to K=5 to:
-- Reduce cycle time (10s instead of 20s)
-- Lower computational cost
-- Still achieve 7 dB SNR gain
-- Provide faster feedback in field testing
+K (fold count) is configurable via `--k` (default 5). The default K=5 balances:
+- Cycle time (~10 s at tip=2.0 s)
+- Computational cost
+- 7 dB SNR gain over single-pulse detection
+- Fast feedback in field testing
 
-For very weak tags, increasing K back to 10 would improve sensitivity at the cost of longer detection latency.
+Higher K (e.g. 20) increases sensitivity (+13 dB) at the cost of longer cycles (~27 s) and longer EVT cache generation on first run. The fractional PRI fix ensures fold alignment is accurate at any K.
 
 ### Why Stateless?
 

--- a/detector/README.md
+++ b/detector/README.md
@@ -1,6 +1,6 @@
 # VHF Pulse Detector
 
-Python-based pulse detector for Sirtrack wildlife radio collars. Implements K-fold coherent integration with Extreme Value Theory (EVT) thresholding for robust detection under non-Gaussian noise conditions.
+Python-based pulse detector for crystal-oscillator wildlife radio collars. Implements K-fold coherent integration with Extreme Value Theory (EVT) thresholding for robust detection under non-Gaussian noise conditions.
 
 ## Overview
 
@@ -514,7 +514,7 @@ In clean RF environments, both methods perform similarly. In harsh environments,
 
 - **UAV-RT Detection System:** https://github.com/dynamic-and-active-systems-lab/uavrt_detection
 - **Extreme Value Theory:** Coles, S. (2001). *An Introduction to Statistical Modeling of Extreme Values*. Springer.
-- **Sirtrack Tags:** https://www.sirtrack.com/
+
 
 ## License
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Simplified VHF Pulse Detector for Sirtrack Crystal-Oscillator Collars
+VHF Pulse Detector for Crystal-Oscillator Radio Collars
 
 Reads decimated IQ data from the airspyhf_zeromq + decimator pipeline via UDP.
 Assumes crystal-oscillator timing (ti_pu=0, ti_pj=0) — no uncertainty or jitter.
-Performs K=5 pulse folding and resets completely after each cycle.
+Performs K-fold pulse integration (configurable via --k) and resets completely after each cycle.
 
 Pipeline:
   airspyhf_zeromq_rx ---> [ZMQ PUB] ---> decimator ---> [UDP] ---> this script
@@ -38,7 +38,7 @@ import numpy as np
 from scipy.linalg import toeplitz as scipy_toeplitz
 from scipy.stats import gumbel_r
 
-K = 5  # Always 5-fold
+K = 5  # Default fold count, overridden by --k
 
 # Detection status values (mirrors TunnelProtocol.h detection_status field)
 DETECTION_STATUS_SUBTHRESHOLD  = 0  # Subthreshold pulse
@@ -199,7 +199,7 @@ def build_weighting_matrix(n_w, Fs, zetas=None):
 # STFT
 # ---------------------------------------------------------------------------
 
-def compute_stft_power(iq, n_w, n_ol, nfft, W=None):
+def compute_stft_power(iq, n_w, n_ol, nfft, W=None, min_windows=None):
     """Compute power spectrogram via overlapped short-time FFT.
 
     When W (spectral weighting matrix) is provided, the FFT is computed at
@@ -208,21 +208,24 @@ def compute_stft_power(iq, n_w, n_ol, nfft, W=None):
     When W is None, a zero-padded FFT of size nfft is used directly.
 
     Args:
-        iq:   1-D complex64 array of IQ samples
-        n_w:  STFT window length (= pulse width in samples)
-        n_ol: overlap in samples
-        nfft: FFT length (used only when W is None)
-        W:    Optional (n_w, n_freq) spectral weighting matrix
+        iq:          1-D complex64 array of IQ samples
+        n_w:         STFT window length (= pulse width in samples)
+        n_ol:        overlap in samples
+        nfft:        FFT length (used only when W is None)
+        W:           Optional (n_w, n_freq) spectral weighting matrix
+        min_windows: Minimum number of STFT windows required (default: K)
 
     Returns:
         power:     (n_freq, n_windows) float32 power spectrogram, DC-centred
         n_windows: number of time windows
     """
+    if min_windows is None:
+        min_windows = K
     n_ws = n_w - n_ol
     n_windows = (len(iq) - n_ol) // n_ws
     n_freq = W.shape[1] if W is not None else nfft
 
-    if n_windows < K:
+    if n_windows < min_windows:
         return np.empty((n_freq, 0), dtype=np.float32), 0
 
     # Rectangular window — matched to rectangular VHF pulse shape (matches
@@ -251,7 +254,8 @@ def compute_stft_power(iq, n_w, n_ol, nfft, W=None):
 # ---------------------------------------------------------------------------
 
 def generate_evt_threshold(n_w, n_ol, nfft, samples_needed, N, K, pf,
-                           W=None, n_trials=100, debug=False):
+                           fold_offsets=None, W=None, n_trials=100,
+                           debug=False):
     """Generate detection threshold via Extreme Value Theory.
 
     Runs Monte Carlo simulation with synthetic complex Gaussian noise through
@@ -288,13 +292,13 @@ def generate_evt_threshold(n_w, n_ol, nfft, samples_needed, N, K, pf,
         if n_time == 0:
             continue
 
-        max_start = n_time - (K - 1) * N
+        _fo = fold_offsets if fold_offsets is not None else np.arange(K) * N
+        max_start = n_time - _fo[-1]
         if max_start <= 0:
             continue
         search_range = min(N, max_start)
 
-        pulse_idx = (np.arange(search_range)[:, None]
-                     + np.arange(K)[None, :] * N)
+        pulse_idx = np.arange(search_range)[:, None] + _fo[None, :]
 
         fold_scores = np.sum(power[:, pulse_idx], axis=2)
 
@@ -377,13 +381,13 @@ def save_evt_cache(cache_dir, N, K, mu, sigma, n_trials=100):
 # ---------------------------------------------------------------------------
 
 def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
-                evt_threshold_cache, W=None, Wf=None, debug=False,
-                detection_margin=0.90):
+                evt_threshold_cache, fold_offsets=None, W=None, Wf=None,
+                debug=False, detection_margin=0.90):
     """Fold power spectrogram at PRI and detect pulses.
 
     With tipu=0, tipj=0 the only free parameter is the first-pulse offset
     within one PRI (0 … N-1 STFT windows).  For each frequency bin we sum
-    K=5 power values spaced exactly N apart and compare against an
+    K power values at the precomputed fold offsets and compare against an
     EVT-derived threshold.
 
     Args:
@@ -404,15 +408,17 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     """
     _, n_time = power.shape
 
+    # Per-fold window offsets (fractional PRI, independently rounded)
+    _fo = fold_offsets if fold_offsets is not None else np.arange(K) * N
+
     # Maximum valid first-pulse position
-    max_start = n_time - (K - 1) * N
+    max_start = n_time - _fo[-1]
     if max_start <= 0:
         return [], float('nan'), None
     search_range = min(N, max_start)
 
     # Index matrix: (search_range, K) — each row is one candidate pattern
-    pulse_idx = (np.arange(search_range)[:, None]
-                 + np.arange(K)[None, :] * N)
+    pulse_idx = np.arange(search_range)[:, None] + _fo[None, :]
 
     # Fold across all frequencies at once: (n_freq, search_range)
     fold_scores = np.sum(power[:, pulse_idx], axis=2)
@@ -474,8 +480,8 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         else:
             print('  [Generating EVT threshold via 100 noise trials...]', flush=True)
             base_threshold, mu, sigma = generate_evt_threshold(
-                n_w, n_ol, nfft, samples_needed, N, K, pf, W=W, n_trials=100,
-                debug=debug
+                n_w, n_ol, nfft, samples_needed, N, K, pf,
+                fold_offsets=_fo, W=W, n_trials=100, debug=debug
             )
             if np.isinf(base_threshold):
                 print(f'ERROR: Insufficient data for EVT threshold. '
@@ -555,7 +561,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         score_ratio = float(best_scores[b] / max(threshold[b], 1e-30))
         # Per-fold diagnostics: individual on-window powers and SNRs
         t0 = int(best_offsets[b])
-        on_idx = t0 + np.arange(K) * N
+        on_idx = t0 + _fo
         on_powers = power[b, on_idx]
         fold_snrs_db = (10.0 * np.log10(on_powers / noise_power[b])).tolist()
         uniformity = float(on_powers.min() / max(on_powers.max(), 1e-30))
@@ -594,7 +600,7 @@ def main():
     global _should_stop
 
     ap = argparse.ArgumentParser(
-        description='Sirtrack VHF Pulse Detector (K=5, EVT threshold)',
+        description='VHF Pulse Detector (configurable K, EVT threshold)',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__)
     ap.add_argument('--tp',  type=float, default=0.015,
@@ -623,7 +629,12 @@ def main():
                     help='EVT threshold multiplier, lower = more sensitive (default: 0.90)')
     ap.add_argument('--confidence-ratio', type=float, default=1.3,
                     help='Score/threshold ratio for confirmed status (default: 1.3)')
+    ap.add_argument('--k', type=int, default=5,
+                    help='Number of pulses to fold/integrate (default: 5)')
     args = ap.parse_args()
+
+    global K
+    K = args.k
 
     # --- Validate parameters ---
     if args.pf <= 0 or args.pf >= 1:
@@ -640,6 +651,8 @@ def main():
         sys.exit(f'Error: --detection-margin must be positive, got {args.detection_margin}')
     if args.confidence_ratio <= 0:
         sys.exit(f'Error: --confidence-ratio must be positive, got {args.confidence_ratio}')
+    if args.k < 2:
+        sys.exit(f'Error: --k must be >= 2, got {args.k}')
 
     # --- STFT geometry ---
     n_w  = int(np.ceil(args.tp * args.fs))
@@ -648,7 +661,18 @@ def main():
                  f'Check --tp and --fs.')
     n_ol  = n_w // 2
     n_ws  = n_w - n_ol
-    N     = int(np.floor(args.tip * args.fs / n_ws))
+    N_exact = args.tip * args.fs / n_ws   # fractional PRI in STFT windows
+    N     = int(np.floor(N_exact))
+
+    # Precompute per-fold window offsets using fractional PRI.
+    # Using integer N (= floor(N_exact)) would accumulate drift of
+    # (N_exact - N) windows per fold — at fold k the pulse lands
+    # (k * N_exact) windows from the start, but integer stride puts
+    # it at (k * N), off by k * (N_exact - N).  For K=20 and
+    # N_exact=176.51 this reaches 9.6 windows by fold 19, missing
+    # the pulse entirely.  Rounding each offset independently keeps
+    # the error bounded to ±0.5 windows regardless of K.
+    fold_offsets = np.round(np.arange(K) * N_exact).astype(int)
 
     # Validate N is sufficient for K-fold integration
     if N < K:
@@ -676,18 +700,21 @@ def main():
         if dead_cols > 0:
             print(f'[DEBUG W] WARNING: {dead_cols} columns have near-zero norm!')
 
-    samples_needed = n_ws * (K * N + 1) + n_ol
+    # N search positions (0..N-1) + last fold offset + 1 for fencepost,
+    # converted to samples; +n_ol because the first STFT window is n_w wide
+    # but only n_ws is counted per step.
+    samples_needed = n_ws * (N + fold_offsets[-1] + 1) + n_ol
     seg_sec  = samples_needed / args.fs
     freq_res = args.fs / nfft
     fa_per_hour = (3600.0 / seg_sec) * args.pf
 
-    print('=== Sirtrack VHF Pulse Detector ===')
+    print('=== VHF Pulse Detector ===')
     print(f'  Pulse width     {args.tp * 1000:.1f} ms')
     print(f'  Inter-pulse     {args.tip:.3f} s')
     print(f'  Folds (K)       {K}')
     print(f'  Sample rate     {args.fs:.1f} Hz')
     print(f'  STFT            window={n_w}  overlap={n_ol}  step={n_ws}')
-    print(f'  PRI (N)         {N} STFT windows')
+    print(f'  PRI (N)         {N} STFT windows  (exact {N_exact:.4f})')
     print(f'  Freq bins       {nfft}  ({freq_res:.1f} Hz resolution, W matrix)')
     print(f'  Segment         {samples_needed} samples  ({seg_sec:.1f} s)')
     print(f'  False alarm %   {args.pf * 100:.2g}%  '
@@ -924,7 +951,9 @@ def main():
             detections, nodet_noise_psd, best_candidate = fold_detect(
                                      power, N, args.pf, args.fs, nfft,
                                      n_w, n_ol, samples_needed,
-                                     evt_threshold_cache, W=W, Wf=Wf,
+                                     evt_threshold_cache,
+                                     fold_offsets=fold_offsets,
+                                     W=W, Wf=Wf,
                                      debug=args.debug,
                                      detection_margin=args.detection_margin)
             proc_ms = (time.monotonic() - t0) * 1000.0

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -12,7 +12,7 @@ Pipeline:
 The decimator must include this script's --port in its --ports list.
 
 Algorithm (per cycle):
-  1. Accumulate ~10 s of decimated IQ (enough for 5 pulse intervals)
+  1. Accumulate decimated IQ (enough for K pulse intervals)
   2. Compute STFT with window matched to pulse width (50% overlap)
   3. Fold the power spectrogram at the exact PRI (no M/J expansion)
   4. Threshold using Extreme Value Theory (Monte Carlo noise trials)
@@ -199,7 +199,7 @@ def build_weighting_matrix(n_w, Fs, zetas=None):
 # STFT
 # ---------------------------------------------------------------------------
 
-def compute_stft_power(iq, n_w, n_ol, nfft, W=None, min_windows=None):
+def compute_stft_power(iq, n_w, n_ol, nfft, W=None, min_windows=1):
     """Compute power spectrogram via overlapped short-time FFT.
 
     When W (spectral weighting matrix) is provided, the FFT is computed at
@@ -213,14 +213,12 @@ def compute_stft_power(iq, n_w, n_ol, nfft, W=None, min_windows=None):
         n_ol:        overlap in samples
         nfft:        FFT length (used only when W is None)
         W:           Optional (n_w, n_freq) spectral weighting matrix
-        min_windows: Minimum number of STFT windows required (default: K)
+        min_windows: Minimum number of STFT windows required (default: 1)
 
     Returns:
         power:     (n_freq, n_windows) float32 power spectrogram, DC-centred
         n_windows: number of time windows
     """
-    if min_windows is None:
-        min_windows = K
     n_ws = n_w - n_ol
     n_windows = (len(iq) - n_ol) // n_ws
     n_freq = W.shape[1] if W is not None else nfft
@@ -288,7 +286,8 @@ def generate_evt_threshold(n_w, n_ol, nfft, samples_needed, N, K, pf,
                    * np.float32(1.0 / np.sqrt(2.0))
 
         # Run through the exact same STFT pipeline as real data
-        power, n_time = compute_stft_power(noise_iq, n_w, n_ol, nfft, W=W)
+        power, n_time = compute_stft_power(noise_iq, n_w, n_ol, nfft, W=W,
+                                           min_windows=K)
         if n_time == 0:
             continue
 
@@ -924,7 +923,8 @@ def main():
             had_gap = segment_has_gap
             segment_has_gap = False
 
-            power, n_win = compute_stft_power(segment, n_w, n_ol, nfft, W=W)
+            power, n_win = compute_stft_power(segment, n_w, n_ol, nfft, W=W,
+                                               min_windows=K)
 
             if args.debug:
                 seg_mag = np.abs(segment)

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -394,7 +394,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
 
     Returns:
         (detections, noise_psd, best_candidate) where:
-          detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score,
+          detections: list of (freq_hz, snr_db, offset, noise_psd,
                       score_ratio, fold_info) sorted by SNR descending.
                       fold_info is a dict with 'uniformity' (float) and
                       'fold_snrs' (list of per-fold SNRs in dB).
@@ -553,8 +553,6 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         # noise floor.  Matches uavrt_detection's reporting convention
         # (fold_score / noise, NOT fold_score / (K * noise)).
         snr_db = 10.0 * np.log10(best_scores[b] / noise_power[b])
-        # Raw fold score for the stft_score field (proportional to pulse PSD)
-        stft_score = float(best_scores[b] / psd_scale)
         # Score-to-threshold ratio: how far above threshold this detection is.
         # Values near 1.0 are marginal (likely false alarm); >>1 is confident.
         score_ratio = float(best_scores[b] / max(threshold[b], 1e-30))
@@ -566,7 +564,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         uniformity = float(on_powers.min() / max(on_powers.max(), 1e-30))
         fold_info = {'uniformity': uniformity, 'fold_snrs': fold_snrs_db}
         results.append((freq_axis[b], snr_db, int(best_offsets[b]),
-                         float(noise_power[b] / psd_scale), stft_score,
+                         float(noise_power[b] / psd_scale),
                          score_ratio, fold_info))
 
     results.sort(key=lambda x: -x[1])
@@ -578,11 +576,11 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     min_sep = max(15, nfft // 4)
     merged = []
     used_bins = []
-    for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info in results:
+    for freq_hz, snr_db, offset, noise_psd, score_ratio, fold_info in results:
         b = int(np.argmin(np.abs(freq_axis - freq_hz)))
         if any(abs(b - ub) <= min_sep for ub in used_bins):
             continue
-        merged.append((freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info))
+        merged.append((freq_hz, snr_db, offset, noise_psd, score_ratio, fold_info))
         used_bins.append(b)
         # Report only the strongest detection
         if len(merged) >= 1:
@@ -988,7 +986,7 @@ def main():
                 # detection that is more likely to be a false alarm.  Report
                 # these as SUBTHRESHOLD so the GCS can display them differently.
 
-                for freq_hz, snr_db, offset, noise_psd, stft_score, score_ratio, fold_info in detections:
+                for freq_hz, snr_db, offset, noise_psd, score_ratio, fold_info in detections:
                     is_marginal = score_ratio < confidence_ratio
                     det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
                                   else DETECTION_STATUS_SUPERTHRESHOLD)

--- a/detector/run_detector.sh
+++ b/detector/run_detector.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run the full Sirtrack VHF pulse detection pipeline at 146 MHz.
+# Run the full VHF pulse detection pipeline at 146 MHz.
 #
 #   airspyhf_zeromq_rx  →  [ZMQ]  →  decimator  →  [UDP]  →  pulse_detector.py
 #


### PR DESCRIPTION
## Changes

### Configurable K (fold count)
- K is now set from `TagInfo.k` via the `--k` CLI arg (default 5)
- Validated `K >= 2` at startup

### Fractional PRI fix
- **Root cause:** `N = floor(tip * fs / n_ws)` truncates the fractional PRI. Fold k was placed at `k * N` instead of `k * N_exact`, accumulating drift of `k * (N_exact - N)` windows. For K=20 with N_exact=176.51, fold 19 drifted 9.6 windows (~5× pulse width), completely missing the pulse.
- **Fix:** `fold_offsets = round(arange(K) * N_exact)` — each fold offset is independently rounded, bounding error to ±0.5 windows regardless of K.
- **Verified:** K=5 SNR=66.5 dB, K=20 SNR=72.4 dB — delta +5.9 dB (expected +6.0 dB). All 20 folds show signal.

### --debug-detector controller flag
- New `--debug-detector` CLI flag on the controller forwards `--debug` to the Python detector subprocess for per-cycle diagnostics.

### PulseHandler no-detection logging
- No-detection log line now includes `score_ratio` (best sub-threshold candidate) for near-miss diagnostics.

### Code quality
- `compute_stft_power` takes explicit `min_windows` parameter instead of reading module-level global K
- Updated stale K=5 references in docstrings, argparse description, and module header
- Removed vendor name references from detector code and docs