### PR TITLE
Add detection analysis and antenna design documentation

### DIFF
--- a/MULTIPATH_ANALYSIS.md
+++ b/MULTIPATH_ANALYSIS.md
@@ -1,0 +1,197 @@
+# VHF Multipath Analysis & Mitigation
+
+## Context
+
+This document covers multipath propagation problems encountered during aerial VHF collar telemetry surveys of African wild dog at 5+ km range, using a 680-class quadrotor at 400 ft AGL with an Airspy HF+ and Telenics RA antenna. The bearing solution is computed in TagTracker using an 8-point rotation sweep and Levenberg-Marquardt pattern fitting.
+
+---
+
+## The Geometry Problem
+
+At 400 ft AGL (122 m) and 5 km range, the elevation angle to a ground-level collar is approximately **1.4°**. At this angle:
+
+- The ground-reflected signal path is nearly equal in length to the direct path
+- Over flat savanna, the ground reflection coefficient approaches unity
+- The reflected signal picks up a ~180° phase shift on reflection (vertical polarisation, low angle)
+- The path length difference between direct and reflected is approximately **6 metres** (~3 wavelengths at 146 MHz)
+
+This means small changes in position or altitude shift the interference pattern between constructive and destructive. The system sits at the boundary of a standing wave pattern, producing significant signal fading.
+
+---
+
+## How Multipath Manifests in This System
+
+### In the K-fold Detector (`pulse_detector.py`)
+
+The K=20 integration window spans **40 seconds** at a 2-second PRI. During a static hover, the multipath geometry is completely fixed — every fold sees identical fading conditions. This means:
+
+- **Fold uniformity stays high** even in a deep destructive null — the system cannot distinguish a consistently weak direct signal from a consistently faded one
+- The SNR reported to TagTracker will be uniformly suppressed across all K folds
+- The `uniformity` metric (min/max of `on_powers`) is **not diagnostic** in static hover mode
+
+### In the Bearing Calculation (`RotationInfo.cc`, TagTracker)
+
+As the drone yaws through the 8 bearing slices, the Yagi/RA antenna pattern rotates relative to the fixed multipath geometry. The ground-reflected signal arrives from a roughly fixed horizontal direction. This means:
+
+- At some headings the reflected signal is near the antenna's main lobe → inflated SNR for that slice
+- At other headings the reflected signal is off-axis → attenuated
+- The LM fit sees a per-slice SNR distribution that does **not** conform to the RA-2AK pattern shape
+- This degrades R² and can pull the fitted bearing toward the reflection, not the collar
+
+The **180° ambiguity check** does not catch this — ground reflection arrives from roughly the same horizontal direction as the direct signal and will not trigger the front/back SNR ratio test.
+
+### Current Indicator
+
+**R² is the primary existing diagnostic.** Persistent yellow (R² 0.6–0.85) or red (R² < 0.6) bearing estimates during surveys at this geometry are multipath, not noise. Per-heading residuals from the LM fit identify which specific slices are contaminated.
+
+---
+
+## Proposed Mitigations
+
+### 1. Hardware: Circular Polarisation (Highest Impact)
+
+The fundamental fix. A **right-hand circularly polarised (RHCP)** antenna on the drone causes the ground-reflected signal to arrive as LHCP, which an RHCP antenna strongly rejects. The direct signal from the linearly polarised collar is received with a 3 dB penalty, but the ground reflection suppression is typically 15–25 dB — a net gain under multipath conditions.
+
+For a 3-element Yagi at 146 MHz (half-wave elements, ~102 cm driven element, ~100 cm boom), a phased cross-dipole feed achieves RHCP. The antenna is mechanically simple — single boom, no switching required — and robust for bush operations.
+
+**Note:** Switching to a Yagi requires updating the antenna pattern LUT in `RotationInfo.cc`. The RA-2AK pattern currently hardcoded does not match a Yagi's sharper forward lobe (~60° 3 dB beamwidth) and lower sidelobes. The mounted pattern on the 680 frame should be characterised empirically to account for prop wash and frame reflections.
+
+---
+
+### 2. Targeted Dual-Altitude Re-test (Highest Software Impact)
+
+Instead of a full second 8-heading sweep at a second altitude (which doubles hover time), use the LM residuals from the first sweep to identify only the suspect slices, then re-test just those at a different altitude.
+
+#### Decision Flow
+
+```
+First sweep completes → fitBearing() runs
+    │
+    ├─ R² ≥ 0.85 → Bearing is clean. Done.
+    │
+    └─ R² < 0.85 → Rank slices by |residual| (measured − modelled SNR)
+                        │
+                        └─ Re-test top 2–3 worst-fitting slices at alt ± ~30 ft
+                                │
+                                ├─ Alt1/Alt2 SNR agree within ~2–3 dB
+                                │    → Consistent: true signal. Keep full weight.
+                                │
+                                └─ Alt1/Alt2 SNR diverge significantly
+                                     → Multipath. Down-weight or clamp to lower value.
+                                          │
+                                          └─ Re-run fitBearing() with updated weights
+```
+
+#### Time Cost
+
+| Approach | Extra Time |
+|---|---|
+| Full second sweep (K=20, 8 headings) | ~5–6 minutes |
+| Targeted re-test of 2–3 slices | ~80–120 seconds |
+| R² ≥ 0.85 (no re-test needed) | 0 seconds |
+
+#### Required Code Changes
+
+**`RotationInfo.cc` / `RotationInfo.h`**
+- Store per-slice final residuals after LM convergence (currently computed but discarded)
+- Expose a `sliceResiduals()` accessor for use by the state machine
+- Add optional per-slice weight vector to `fitBearing()` (default all 1.0)
+
+**`SliceInfo.cc`**
+- Add a second SNR value per slice to hold the re-test result, alongside the original value
+- The dual-altitude re-test provides the only opportunity for multiple values per slice — there is one K=20 run per heading per sweep, so no within-sweep averaging is possible
+
+**`RotateAndCaptureStateBase`**
+- After initial sweep and fit, check R² against threshold (suggest 0.85)
+- If below threshold, read per-slice residuals, build targeted heading list
+- Command altitude step, revisit only flagged headings, update slice SNR with weighted values
+- Re-trigger `fitBearing()` with updated slice weights
+
+---
+
+### 3. Altitude as an Operational Variable
+
+The path length difference between direct and reflected signals is:
+
+```
+Δr ≈ 2h × sin(θ)
+```
+
+where `h` is AGL height and `θ` is elevation angle to the collar. At 400 ft / 5 km, `Δr ≈ 6 m`. A **30 ft (~9 m) altitude change** shifts the path length difference by ~0.5 m — roughly a quarter wavelength at 146 MHz — which is enough to move significantly within the interference fringe pattern.
+
+This is why the targeted re-test at a second altitude is effective: it does not need to fully escape the multipath zone, only to sample a sufficiently different point on the standing wave pattern to distinguish consistent signal from fading.
+
+---
+
+### 4. Fold-Level Diagnostics in the Detector
+
+While fold uniformity is not diagnostic during a static hover (all folds see the same geometry), the **variance of `fold_snrs_db` within a single heading** does carry useful information about within-PRI signal stability. Adding this to the UDP pulse report would allow TagTracker to use it as an additional per-detection quality weight.
+
+Suggested addition to `PulseInfo_t`:
+- `fold_snr_variance` — variance of per-fold SNR in dB across K folds
+- `fold_uniformity` — existing min/max ratio
+
+High variance at a given heading, relative to other headings in the sweep, is a secondary multipath indicator even in static hover.
+
+---
+
+### 5. Single-Rotation Bearing Accuracy Improvements
+
+These changes do not address multipath directly but improve the bearing estimate from a clean single rotation.
+
+#### Confirmed-Status Weighting in the LM Fit
+
+The LM fit in `RotationInfo.cc` currently assigns equal weight to all slices regardless of detection quality. `PulseInfo_t` already carries `confirmed_status` (0 = unconfirmed, 1 = confirmed), which indicates whether the detected pulse aligned with a prior pulse prediction. A confirmed detection is a higher-quality measurement than an unconfirmed one.
+
+Adding a per-slice weight vector to the LM cost function — confirmed slices weight 1.0, unconfirmed slices weight 0.5 — would give higher-confidence observations more influence on the fitted bearing. The practical benefit is limited if most detections at 5+ km are unconfirmed, but costs almost nothing to implement.
+
+The change is localised to the cost function and Jacobian computation in `RotationInfo.cc`, and the weight vector would be populated in `RotateAndCaptureStateBase` from the `confirmed_status` field of each received `PulseInfo_t`.
+
+#### Null-Detection Slice Handling
+
+When a heading produces no detection above threshold, `SliceInfo` holds SNR = 0 for that slice, and the current ≥ 3 valid slices check excludes it from the fit. This is the correct behaviour — including SNR = 0 as a real measurement would incorrectly signal to the LM fit that the antenna pattern minimum is at that heading.
+
+However, the K=20 detector computes a fold score for every heading regardless of whether it crosses threshold. That sub-threshold score contains real information: it tells the fit that the signal at that heading is *below* the detection threshold, which constrains the pattern fit even if it is not a confirmed detection. Passing the sub-threshold fold score to TagTracker as a soft measurement with low weight (e.g., 0.25) would allow the LM fit to use this information rather than discarding it entirely.
+
+This requires a change in `pulse_detector.py` to report the fold score and noise estimate even on non-detections, and a corresponding change in `SliceInfo` to store and apply soft measurements separately from hard detections.
+
+#### Pattern LUT Interpolation
+
+The RA-2AK pattern LUT is sampled at 10° resolution. Linear interpolation between 10° steps introduces small errors in the main lobe region where the pattern changes most rapidly. Replacing linear with spline interpolation over the existing LUT would improve fit accuracy near the bearing peak with no new measurements required.
+
+---
+
+## Summary of Recommended Changes by Repository
+
+### `MavlinkTagController2` (`pulse_detector.py`)
+
+| Change | Priority | Effort |
+|---|---|---|
+| Add `fold_snr_variance` to UDP pulse output | Medium | Low |
+| Add `fold_uniformity` to UDP pulse output | Medium | Low |
+| Report sub-threshold fold score and noise estimate on non-detections | Medium | Low–Medium |
+
+### TagTracker (`RotationInfo.cc`, `SliceInfo.cc`, `RotateAndCaptureStateBase`)
+
+| Change | Priority | Effort |
+|---|---|---|
+| Expose per-slice LM residuals after `fitBearing()` | High | Low–Medium |
+| Add second SNR slot per slice for dual-altitude re-test result | High | Low |
+| Implement targeted dual-altitude re-test in state machine | High | Medium |
+| Add per-slice weight vector to LM fit; populate from confirmed status | Low–Medium | Low |
+| Add soft-measurement slot per slice for sub-threshold fold scores | Medium | Low–Medium |
+| Replace linear with spline interpolation on RA-2AK pattern LUT | Low | Low |
+| Update antenna pattern LUT when switching to Yagi | Required for Yagi | Medium |
+
+### Hardware
+
+| Change | Priority |
+|---|---|
+| RHCP feed on Yagi (3-element, 146 MHz) | High — fundamental fix |
+| Characterise mounted Yagi pattern on 680 frame | Required for LUT update |
+
+---
+
+## Notes on Receiver
+
+The Airspy HF+ has high dynamic range and low noise figure at 146 MHz, and is not the limiting factor in this scenario. The multipath problem is geometric and must be addressed at the antenna or the bearing estimation layer. The EVT thresholding in the detector handles non-Gaussian noise statistics well and does not require changes for multipath mitigation.

--- a/MULTIPATH_ANALYSIS.md
+++ b/MULTIPATH_ANALYSIS.md
@@ -141,7 +141,7 @@ These changes do not address multipath directly but improve the bearing estimate
 
 #### Confirmed-Status Weighting in the LM Fit
 
-The LM fit in `RotationInfo.cc` currently assigns equal weight to all slices regardless of detection quality. `PulseInfo_t` already carries `confirmed_status` (0 = unconfirmed, 1 = confirmed), which indicates whether the detected pulse aligned with a prior pulse prediction. A confirmed detection is a higher-quality measurement than an unconfirmed one.
+The LM fit in `RotationInfo.cc` currently assigns equal weight to all slices regardless of detection quality. `PulseInfo_t` already carries `confirmed_status` (0 = unconfirmed, 1 = confirmed), which indicates whether the detection's score_ratio exceeded the confidence_ratio gate (i.e., `score_ratio >= confidence_ratio`). A confirmed detection has a stronger score and is a higher-quality measurement than an unconfirmed one.
 
 Adding a per-slice weight vector to the LM cost function — confirmed slices weight 1.0, unconfirmed slices weight 0.5 — would give higher-confidence observations more influence on the fitted bearing. The practical benefit is limited if most detections at 5+ km are unconfirmed, but costs almost nothing to implement.
 

--- a/MULTIPATH_ANALYSIS.md
+++ b/MULTIPATH_ANALYSIS.md
@@ -52,7 +52,7 @@ The **180° ambiguity check** does not catch this — ground reflection arrives 
 
 The fundamental fix. A **right-hand circularly polarised (RHCP)** antenna on the drone causes the ground-reflected signal to arrive as LHCP, which an RHCP antenna strongly rejects. The direct signal from the linearly polarised collar is received with a 3 dB penalty, but the ground reflection suppression is typically 15–25 dB — a net gain under multipath conditions.
 
-For a 3-element Yagi at 146 MHz (half-wave elements, ~102 cm driven element, ~100 cm boom), a phased cross-dipole feed achieves RHCP. The antenna is mechanically simple — single boom, no switching required — and robust for bush operations.
+For a 3-element Yagi at 146 MHz a phased cross-dipole feed achieves RHCP. See `YAGI_ANTENNA_DESIGN.md` for exact element and boom dimensions. The antenna is mechanically simple — single boom, no switching required — and robust for bush operations.
 
 **Note:** Switching to a Yagi requires updating the antenna pattern LUT in `RotationInfo.cc`. The RA-2AK pattern currently hardcoded does not match a Yagi's sharper forward lobe (~60° 3 dB beamwidth) and lower sidelobes. The mounted pattern on the 680 frame should be characterised empirically to account for prop wash and frame reflections.
 
@@ -117,7 +117,7 @@ The path length difference between direct and reflected signals is:
 Δr ≈ 2h × sin(θ)
 ```
 
-where `h` is AGL height and `θ` is elevation angle to the collar. At 400 ft / 5 km, `Δr ≈ 6 m`. A **30 ft (~9 m) altitude change** shifts the path length difference by ~0.5 m — roughly a quarter wavelength at 146 MHz — which is enough to move significantly within the interference fringe pattern.
+where `h` is AGL height and `θ` is elevation angle to the collar. At 400 ft / 5 km, `Δr ≈ 6 m`. A **30 ft (~9 m) altitude change** shifts the path length difference by about **0.44 m** (~0.21λ at 146 MHz) — which is enough to move significantly within the interference fringe pattern.
 
 This is why the targeted re-test at a second altitude is effective: it does not need to fully escape the multipath zone, only to sample a sufficiently different point on the standing wave pattern to distinguish consistent signal from fading.
 

--- a/YAGI_ANTENNA_DESIGN.md
+++ b/YAGI_ANTENNA_DESIGN.md
@@ -98,7 +98,7 @@ If you purchased the Arrow 146-3, the boom, reflector, and director are already 
 - 1× length of Easton aluminium arrow shaft or 9.5 mm aluminium tube, 966 mm total (2× 483 mm arms) — for the second dipole
 - 1× small aluminium or HDPE cross-hub to mount both dipoles at 90° on the Arrow's 3/4" boom (fabricate from flat stock or 3D print in PETG)
 - 1× BNC T-connector (female-female-male)
-- ~380 mm of RG-59 75-ohm coax with solid PE dielectric (velocity factor 0.66) — for the delay line
+- ~380 mm of RG-59 75-ohm coax with solid PE dielectric (velocity factor 0.66) — starting stock length, to be trimmed to a 338 mm delay line
 - 2× BNC male connectors to terminate the delay line
 - Heat shrink and self-amalgamating tape for weatherproofing
 
@@ -110,7 +110,7 @@ If you purchased the Arrow 146-3, the boom, reflector, and director are already 
 Physical length = 512 mm × 0.66 = 338 mm
 ```
 
-Cut the RG-59 to **338 mm** tip-to-tip including the connectors. Verify electrically with a VNA — the line should present a short circuit at 146.5 MHz when the far end is open, or an open circuit when the far end is shorted.
+**338 mm** is the electrical quarter-wave target for the coax section. Connector bodies add physical length, so cut the RG-59 slightly long, fit the BNC connectors, then verify and trim with a VNA until the assembled delay line is an electrical λ/4 at 146.5 MHz. The line should present a short circuit at 146.5 MHz when the far end is open, or an open circuit when the far end is shorted.
 
 **Assembly steps:**
 

--- a/YAGI_ANTENNA_DESIGN.md
+++ b/YAGI_ANTENNA_DESIGN.md
@@ -1,0 +1,229 @@
+# 3-Element Yagi Antenna Design — 146–147 MHz Drone Telemetry
+
+## Why a 3-Element Yagi
+
+The RA-2AK is a broad-pattern antenna well-suited to handheld surveys where the operator sweeps slowly. For a drone platform doing an 8-point rotation sweep with LM pattern fitting, the antenna beamwidth is the primary limit on bearing resolution — the LM fit has more angular gradient to work with as the beam narrows. A 3-element Yagi offers a practical balance:
+
+| Antenna | Gain (dBd) | 3dB Beamwidth | Boom Length | Verdict |
+|---|---|---|---|---|
+| RA-2AK (current) | ~1–2 | ~120° | — | Broad, limits bearing resolution |
+| 2-element Yagi | ~5 | ~90° | ~35 cm | Modest improvement, short boom |
+| **3-element Yagi** | **~7.5** | **~65°** | **~82 cm** | **Best balance for 680 class** |
+| 4-element Yagi | ~9 | ~55° | ~130 cm | Diminishing return, too long |
+| 5-element Yagi | ~10 | ~50° | ~200 cm | Not viable on 680 class |
+
+The 3-element is the inflection point: the jump from RA-2AK to 3-element Yagi is large (~5–6 dBd gain, roughly half the beamwidth). The jump from 3-element to 4-element is much smaller and comes at significant cost in boom length and drag.
+
+At 5+ km with K=20 integration and the Airspy HF+, signal strength is not the limiting factor. The gain matters less than the pattern shape for bearing accuracy, and the Yagi's sharper lobe gives the LM fit a much steeper gradient near boresight.
+
+---
+
+## Off-the-Shelf Option: Arrow Antenna 146-3
+
+For the linear (non-RHCP) version, the **Arrow Antenna 146-3** is a direct match to the design spec and does not need to be built from scratch.
+
+**Purchase links:**
+- [Arrow Antenna direct (146-3ii)](http://www.arrowantennas.com/arrowii/146-3ii.html) — ~USD $114
+- [GigaParts](https://www.gigaparts.com/arrow-antennas-146-3.html) — ~USD $114, in stock, free shipping
+- [Amazon (146-3)](https://www.amazon.com/Arrow-Handheld-Portable-Antenna-146-3/dp/B00TGE64KG) — ~USD $114
+
+**What you get:**
+- 3-element Yagi tuned specifically to 146 MHz (not just band coverage)
+- 3/4" T6061 aluminium boom
+- Easton aluminium arrow shafts for elements (lightweight, stiff)
+- Pre-tuned gamma match at the feedpoint — no tuning required
+- SWR 1.2:1 at 146 MHz
+- Foam handle grip that removes cleanly for drone mounting
+- Compatible with the Arrow II Mounting Bracket (sold separately) for mast/boom attachment
+
+**Adapter required:** The Arrow 146-3 has a **BNC connector only**. The Airspy HF+ uses SMA. A BNC-female to SMA-male adapter is needed — use a quality silver-plated one, not a cheap brass adapter, to avoid additional loss at this frequency.
+
+**Drone mount:** Remove the foam grip and fabricate a simple bracket from aluminium flat stock to clamp the 3/4" boom to your drone frame standoff. The Arrow II Mounting Bracket can also be used if it suits your standoff geometry.
+
+**For RHCP:** The Arrow provides the boom, reflector, and director — the three components you would otherwise have to build. The driven element is then replaced as described in the RHCP modification section below.
+
+---
+
+## Design Dimensions — 146.5 MHz Centre Frequency
+
+Element diameter: **9.5 mm (3/8") 6061-T6 aluminium tube**
+
+At this diameter, the element length correction for end-effect is small but included below.
+
+### Element Lengths
+
+| Element | Length (mm) | Half-length each side (mm) |
+|---|---|---|
+| Reflector | 1026 | 513 |
+| Driven element | 965 | 483 |
+| Director | 910 | 455 |
+
+### Boom Spacings (measured from reflector)
+
+| Element | Position on boom |
+|---|---|
+| Reflector | 0 mm |
+| Driven element | 410 mm |
+| Director | 820 mm |
+
+**Total boom length: 820 mm**
+
+### Feedpoint Impedance
+
+A split-dipole driven element at this spacing presents approximately **28–35 ohms**. Two matching options are practical for field use:
+
+**Gamma match (recommended for bush conditions):** Directly matches to 50-ohm coax. No balun required. Mechanically simple — a short aluminium rod and a small series capacitor. Robust and adjustable. Set the gamma rod to approximately 120 mm length and 12 mm spacing from the driven element; tune the series capacitor (start at 7–10 pF) for minimum SWR.
+
+**Folded dipole driven element:** Raises feedpoint impedance to ~120–140 ohms. With a λ/4 coaxial impedance transformer (75-ohm coax cut to 340 mm electrical length), presents ~50 ohms. More complex construction than the gamma match but no moving parts and no capacitor to drift.
+
+Avoid direct-connection 50-ohm matching without a balun — common-mode currents on the coax will distort the pattern and corrupt the bearing measurement.
+
+---
+
+## RHCP Variant for Multipath Mitigation
+
+As described in `MULTIPATH_ANALYSIS.md`, the ground-reflected signal arrives as opposite-hand circular polarisation. An RHCP antenna strongly rejects it.
+
+The simplest RHCP implementation for a Yagi is a **crossed-dipole driven element with 90° hybrid feed**:
+
+- Two dipoles at 90° to each other replace the single driven element, both at the same boom position
+- A 90° hybrid coupler (coaxial λ/4 delay line) feeds them in quadrature
+- The reflector and director remain unchanged — parasitic elements still provide pattern shaping under a circularly polarised driven element (gain and F/B ratio reduced slightly, ~1–2 dB, vs the linear version)
+
+### Modifying the Arrow 146-3 for RHCP
+
+If you purchased the Arrow 146-3, the boom, reflector, and director are already built. Only the driven element needs modification.
+
+**Parts needed:**
+- 1× length of Easton aluminium arrow shaft or 9.5 mm aluminium tube, 966 mm total (2× 483 mm arms) — for the second dipole
+- 1× small aluminium or HDPE cross-hub to mount both dipoles at 90° on the Arrow's 3/4" boom (fabricate from flat stock or 3D print in PETG)
+- 1× BNC T-connector (female-female-male)
+- ~380 mm of RG-59 75-ohm coax with solid PE dielectric (velocity factor 0.66) — for the delay line
+- 2× BNC male connectors to terminate the delay line
+- Heat shrink and self-amalgamating tape for weatherproofing
+
+**Delay line length:**
+
+λ/4 at 146.5 MHz in free space = 512 mm. With solid-PE RG-59 (velocity factor 0.66):
+
+```
+Physical length = 512 mm × 0.66 = 338 mm
+```
+
+Cut the RG-59 to **338 mm** tip-to-tip including the connectors. Verify electrically with a VNA — the line should present a short circuit at 146.5 MHz when the far end is open, or an open circuit when the far end is shorted.
+
+**Assembly steps:**
+
+1. **Remove the Arrow's original driven element** from the boom. Retain the gamma match assembly — this becomes the feed for dipole A.
+
+2. **Fabricate the cross-hub.** A simple flat plate of 3 mm aluminium with two perpendicular slots to accept the boom and the second dipole mounting tube works well. The second dipole must be electrically isolated from the boom (HDPE sleeve or nylon spacers).
+
+3. **Mount dipole A** (the original Arrow driven element with gamma match) back on the boom at the original position, oriented horizontally.
+
+4. **Mount dipole B** (the new element) at the same boom position, oriented vertically, with arms of 483 mm each side. Match dipole B to 50 ohms — the simplest approach is a second gamma match identical to the Arrow's original. Alternatively, a split dipole centre-fed through a 1:1 balun (choke balun, 5 turns of RG-58 through a FT-50-43 toroid) works well and is more predictable.
+
+5. **Feed arrangement:**
+   - Main feedline from Airspy HF+ → BNC T-connector
+   - T port 1 → dipole A gamma match (direct connection)
+   - T port 2 → 338 mm RG-59 delay line → dipole B feedpoint
+   - This phase-shifts dipole B by 90°, producing circular polarisation
+
+6. **Weatherproof the feedpoint.** Self-amalgamating tape over all connectors, then heat shrink over the assembly. In African conditions moisture ingress at the BNC joints is the most common failure point.
+
+**Handedness:** With the antenna pointing forward and dipole A horizontal, the configuration above produces RHCP when viewed from behind (signal rotates clockwise looking forward). To verify: rotate a linearly polarised test transmitter from 45° to 135° tilt — the received SNR should remain within 1–2 dB across both orientations. If the SNR varies more than ~3 dB, one dipole is mismatched or the delay line length is off.
+
+To flip to LHCP if needed, swap which dipole receives the delay line.
+
+---
+
+## Materials and Construction for African Bush
+
+**Boom:** 20 mm square or round 6061-T6 aluminium extrusion. Square section prevents element rotation without requiring clamps. Minimum wall thickness 2 mm.
+
+**Elements:** 9.5 mm OD 6061-T6 round tube. Each element passes through a hole in the boom and is secured with a nylon set-screw on each side. **Electrically isolate the driven element from the boom** (nylon or HDPE sleeve through the boom hole). Reflector and director can be electrically bonded to boom or isolated — electrically bonded simplifies construction and has negligible pattern effect.
+
+**Corrosion:** Aluminium performs well in the bush environment. Anodising is useful but not essential. All fasteners should be stainless steel or aluminium. Avoid dissimilar metal contact (e.g. steel bolts into aluminium threads) without an isolating washer.
+
+**Feedline:** LMR-195 or Belden 8240 from feedpoint to drone frame (short, 200–300 mm). Then LMR-240 from frame to Airspy HF+. Keep the feedpoint coax transition away from the driven element to avoid pattern distortion. A small PL-259/SMA adapter mount potted in epoxy makes a durable feedpoint junction.
+
+**Weight estimate:**
+- Boom (820 mm, 20mm square, 2mm wall): ~95 g
+- Three elements (9.5mm tube): ~75 g
+- Feedpoint hardware, clamps, coax stub: ~40 g
+- **Total: ~210 g**
+
+---
+
+## Mounting on the 680 Frame
+
+**Position:** Below the frame on the centreline, boom aligned fore-and-aft. This puts the main lobe pointing forward in the drone's reference frame and keeps elements clear of props.
+
+**Standoff:** Minimum 80 mm below the frame. Carbon fibre frame members detune the antenna if they pass through the near field. Test with VNA before field deployment — a carbon frame at 80 mm will shift resonance measurably.
+
+**Fore-aft alignment:** The driven element should be forward of the drone's centre of mass so that the main lobe direction (forward) corresponds to the drone's nose heading as reported by the flight controller. Verify the bearing offset between antenna boresight and FC compass heading during initial calibration and apply as a fixed offset in `RotateAndCaptureStateBase`.
+
+**Downward tilt:** A 1–2° nose-down tilt on the boom angles the main lobe toward ground-level collars at distance. At 400 ft AGL / 5 km, the geometric depression angle is 1.4°, so this is a reasonable match. Tilt is easily achieved with a wedge-shaped mount.
+
+**Drag:** At typical survey airspeeds the 820 mm boom presents significant drag asymmetry. Fly in hover or slow creep during detection cycles. If ferrying between hover points at speed, orient the antenna axis fore-and-aft (which it already is) to minimise frontal area.
+
+---
+
+## Pattern Characteristics and TagTracker Integration
+
+### Expected pattern at 146.5 MHz (linear polarisation)
+
+| Parameter | Value |
+|---|---|
+| Forward gain | ~7.5 dBd |
+| 3 dB beamwidth (E-plane) | ~65° |
+| Front-to-back ratio | ~10–12 dB |
+| First sidelobe level | ~–13 dB |
+
+### Pattern LUT update required
+
+`RotationInfo.cc` in TagTracker contains a hardcoded empirical pattern LUT for the RA-2AK antenna sampled at 10° intervals. **This must be replaced before flying the Yagi.** Using the wrong pattern in the LM fit will produce systematically biased bearings.
+
+The Yagi pattern is well-approximated theoretically but the mounted pattern on the 680 frame will differ due to frame and prop reflections. The recommended process:
+
+1. Use the theoretical pattern (tabulated below) as a starting point for initial testing
+2. Mount the antenna on the 680 and measure the actual pattern against a fixed transmitter at known bearing while rotating the drone in a large open area
+3. Sample at 10° intervals (or 5° for better LUT resolution), record SNR at each heading
+4. Fit a smooth curve (spline) to the measurements, re-sample at 10° steps, replace the LUT
+
+### Theoretical 3-element Yagi pattern (linear, E-plane, 10° steps, normalised to 0 dB at boresight)
+
+| Angle (°) | Relative level (dB) |
+|---|---|
+| 0 | 0.0 |
+| 10 | −0.3 |
+| 20 | −1.2 |
+| 30 | −2.9 |
+| 40 | −5.2 |
+| 50 | −8.1 |
+| 60 | −11.6 |
+| 70 | −15.3 |
+| 80 | −18.5 |
+| 90 | −20.4 |
+| 100 | −19.8 |
+| 110 | −17.5 |
+| 120 | −14.9 |
+| 130 | −12.8 |
+| 140 | −11.6 |
+| 150 | −11.2 |
+| 160 | −11.5 |
+| 170 | −12.1 |
+| 180 | −12.4 |
+
+Pattern is symmetric: angle 190° = value at 170°, 200° = 160°, etc.
+
+Note these are free-space values. The mounted pattern will differ, particularly in the rear quadrant where frame reflections have the most effect. Empirical characterisation is essential before operational use.
+
+---
+
+## Verification Before Field Deployment
+
+1. **VNA check:** Measure SWR at 146–147 MHz after mounting on drone (motors off). Target SWR < 1.5:1 across the band. Retune gamma match if needed.
+2. **Pattern check:** Rotate drone against fixed transmitter at 50+ m, confirm peak and null positions match expectations.
+3. **Bearing offset calibration:** Confirm boresight heading matches FC compass heading; apply fixed correction in TagTracker if not.
+4. **RHCP handedness (if built):** Verify correct handedness as described above before flying.
+5. **LUT update in TagTracker:** Do not fly with the RA-2AK LUT still active.

--- a/YAGI_ANTENNA_DESIGN.md
+++ b/YAGI_ANTENNA_DESIGN.md
@@ -183,6 +183,8 @@ To flip to LHCP if needed, swap which dipole receives the delay line.
 
 `RotationInfo.cc` in TagTracker contains a hardcoded empirical pattern LUT for the RA-2AK antenna sampled at 10° intervals. **This must be replaced before flying the Yagi.** Using the wrong pattern in the LM fit will produce systematically biased bearings.
 
+**Repository note:** `RotationInfo.cc` and related classes such as `RotateAndCaptureStateBase` are part of the separate TagTracker application codebase (QGroundControl fork); they are not in this monorepo.
+
 The Yagi pattern is well-approximated theoretically but the mounted pattern on the 680 frame will differ due to frame and prop reflections. The recommended process:
 
 1. Use the theoretical pattern (tabulated below) as a starting point for initial testing

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -1,0 +1,326 @@
+# Confidence Classification Improvements
+
+Changes needed to reduce false-positive detections that currently pass the
+confidence gate. Motivated by Apr-11 field data where Flight 2 produced 8/8
+Conf:1 detections that were all transient/RFI artifacts.
+
+## Problem Summary
+
+The current confidence classification uses a single test:
+
+```python
+is_marginal = score_ratio < confidence_ratio   # default 1.3
+```
+
+This is necessary but insufficient. Flight 2 (5.75 km, 8 headings) produced
+score_ratios of 1.3–2.6 on every heading — all classified Conf:1 — yet:
+
+- Uniformity was 0.000–0.004 on all 8 headings (single-fold spikes)
+- Frequency offsets ranged from −1192 to +1622 Hz (2,814 Hz spread)
+- Peak bearing was 48° off the true collar direction
+
+Each heading independently detected a different noise/RFI transient at a
+different frequency. The score_ratio gate cannot catch this.
+
+---
+
+## Change 1: Uniformity Gate in Detector
+
+**Priority: High — biggest single impact, minimal code change**
+
+### What
+
+Add a uniformity threshold to the detection decision. Detections with
+uniformity below the threshold are downgraded to SUBTHRESHOLD regardless
+of score_ratio.
+
+### Where
+
+[pulse_detector.py](pulse_detector.py), in the detection reporting loop
+(currently ~line 988).
+
+### Current code
+
+```python
+is_marginal = score_ratio < confidence_ratio
+det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
+              else DETECTION_STATUS_SUPERTHRESHOLD)
+```
+
+### Proposed code
+
+```python
+is_marginal = (score_ratio < confidence_ratio
+               or fold_info['uniformity'] < min_uniformity)
+det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
+              else DETECTION_STATUS_SUPERTHRESHOLD)
+```
+
+### New CLI argument
+
+```
+--min-uniformity  (default: 0.10)
+```
+
+### Threshold rationale
+
+| Uniformity | Meaning | Action |
+|------------|---------|--------|
+| < 0.10 | ≤1 fold dominates — transient/spike | Downgrade to LOW |
+| 0.10–0.25 | Marginal — possible weak signal with fading | Pass (conservative) |
+| > 0.25 | Multiple folds contributing — consistent pulse train | Pass |
+
+The 0.10 starting point is deliberately conservative. It only rejects cases
+where one fold has ≥10× the power of the weakest — clearly not a periodic
+pulse. This would have rejected all 8 Flight 2 detections (uniformity
+0.000–0.004) without affecting any Flight 4 real detections.
+
+See [CROSS_RATE_REJECTION.md](CROSS_RATE_REJECTION.md) for the full design.
+
+### Impact on existing detections
+
+Reviewing all field data:
+
+| Flight | Real signal? | Uniformity range | Affected? |
+|--------|-------------|------------------|-----------|
+| Apr-9 K=10 (4 km) | Yes | Not available (pre-uniformity) | No |
+| Apr-11 Flight 2 (5.75 km) | No — RFI | 0.000–0.004 | **Yes — all 8 downgraded** |
+| Apr-11 Flight 3 (7.03 km) | Marginal | 0.001–0.029 | Some at 0.001–0.004 |
+| Apr-11 Flight 4 (2.84 km) | Partial | 0.001–0.009 | Conf:1 headings at 0.001 |
+
+Flight 4's three Conf:1 headings (90°, 135°, −135°) have uniformity 0.001,
+which is below 0.10. These would be downgraded. This is a debatable call —
+they had the correct bearing pattern — but their uniformity values are
+indistinguishable from the Flight 2 garbage. If real signal at 2.84 km
+produces uniformity this low, the threshold may need to be lowered to 0.005,
+or the uniformity metric itself may need refinement (see open questions below).
+
+---
+
+## Change 2: On/Off Contrast Test in Detector
+
+**Priority: Medium — covers CW interference, different failure mode**
+
+### What
+
+After a detection exceeds the EVT threshold, compare mean power in the K
+on-windows vs mean power in all off-windows. CW interference has near-equal
+power everywhere; a real pulse has high on/off contrast.
+
+### Where
+
+[pulse_detector.py](pulse_detector.py), in the fold detection function,
+after computing `on_powers` and before building `fold_info`.
+
+### Proposed code
+
+```python
+off_mask = np.ones(power.shape[1], dtype=bool)
+off_mask[on_idx] = False
+off_power = power[b, off_mask].mean()
+on_power = on_powers.mean()
+contrast_db = 10.0 * np.log10(on_power / max(off_power, 1e-30))
+
+fold_info['contrast_db'] = float(contrast_db)
+```
+
+Then in the classification:
+
+```python
+is_marginal = (score_ratio < confidence_ratio
+               or fold_info['uniformity'] < min_uniformity
+               or fold_info['contrast_db'] < min_contrast_db)
+```
+
+### New CLI argument
+
+```
+--min-contrast-db  (default: 3.0)
+```
+
+### Threshold rationale
+
+| Contrast | Signal type | Action |
+|----------|-------------|--------|
+| < 3 dB | CW or near-CW interference | Downgrade to LOW |
+| 3–10 dB | Weak pulse or fading | Pass |
+| > 10 dB | Strong pulsed signal | Pass |
+
+See [CW_REJECTION.md](CW_REJECTION.md) for the full design.
+
+---
+
+## Change 3: Add Uniformity to UDP Packet
+
+**Priority: High — needed for controller-side logging and future use**
+
+### What
+
+Add `uniformity` as a 13th field in the UDP pulse packet so the controller
+can log it and downstream consumers (TagTracker) can use it.
+
+### Wire format change
+
+This is a **breaking change** to the detector↔controller interface.
+
+**Detector side** ([pulse_detector.py](pulse_detector.py)):
+
+```python
+# Current: struct.pack('<12d', ...)
+# Proposed: struct.pack('<13d', ..., uniformity)
+```
+
+Add `uniformity` parameter to `send_pulse_udp()` and append it as field 12
+(0-indexed). Packet grows from 96 to 104 bytes.
+
+**Controller side** ([../controller/PulseHandler.h](../controller/PulseHandler.h)):
+
+```cpp
+typedef struct {
+    double tag_id;
+    double frequency_hz;
+    double start_time_seconds;
+    double predict_next_start_seconds;
+    double snr;
+    double stft_score;
+    double group_seq_counter;
+    double group_ind;
+    double group_snr;
+    double detection_status;
+    double confirmed_status;
+    double noise_psd;
+    double uniformity;        // NEW
+} UDPPulseInfo_T;
+```
+
+**Controller side** ([../controller/PulseHandler.cpp](../controller/PulseHandler.cpp)):
+
+Add `uniformity` to the `PulseInfo_t` population and to the log format string:
+
+```
+Conf: %u Id: %2u snr: %5.1f ... uniformity: %.3f ...
+```
+
+**TunnelProtocol** ([../tunnel-protocol/TunnelProtocol.h](../tunnel-protocol/TunnelProtocol.h)):
+
+Add `uniformity` field to `PulseInfo_t` if it needs to be forwarded to the
+GCS via MAVLink tunnel.
+
+### Both sides must be updated in the same commit.
+
+---
+
+## Change 4: Frequency Consistency Check at Controller Level
+
+**Priority: High — strongest cross-heading discriminator, but more complex**
+
+### What
+
+After a full rotation (8 headings), compare the detected frequencies across
+all headings that reported detections. A real tag produces the same frequency
+(±~100 Hz). Scattered frequencies indicate independent noise/RFI hits.
+
+### Where
+
+This belongs in the **controller**, not the detector, because the detector
+runs as independent per-heading instances with no cross-heading awareness.
+The controller already accumulates per-heading results.
+
+### Proposed logic
+
+```
+After 8-heading rotation completes:
+  detected_freqs = [freq_hz for each heading with detection_status != NO_DETECTION]
+  if len(detected_freqs) >= 3:
+      freq_spread = max(detected_freqs) - min(detected_freqs)
+      if freq_spread > max_freq_spread_hz:   # default: 200 Hz
+          # Downgrade all detections in this rotation to LOW
+          for each detection: confirmed_status = 0
+```
+
+### Where in controller
+
+[../controller/PulseHandler.cpp](../controller/PulseHandler.cpp) or a new
+rotation-level aggregation class. The controller currently processes each
+pulse independently — it would need to buffer a rotation's worth of pulses
+before applying this check.
+
+This is a larger architectural change than the detector-side fixes and should
+be designed carefully. The controller needs to know when a rotation starts
+and ends, which headings belong together, and how to retroactively downgrade
+already-forwarded pulses.
+
+### Alternative: do it in TagTracker
+
+TagTracker already receives all 8 headings for a rotation and fits a bearing
+pattern. The frequency consistency check could live there instead, alongside
+the R² pattern-fit quality metric. This avoids architectural changes in the
+controller.
+
+---
+
+## Change Summary
+
+| # | Change | Where | Priority | Effort | Catches |
+|---|--------|-------|----------|--------|---------|
+| 1 | Uniformity gate | Detector | High | Low | Transient/spike false positives |
+| 2 | On/off contrast | Detector | Medium | Low | CW interference |
+| 3 | Uniformity in UDP | Detector + Controller | High | Low–Med | Enables logging and downstream use |
+| 4 | Frequency consistency | Controller or TagTracker | High | Medium | Cross-heading RFI |
+
+### Recommended implementation order
+
+1. **Change 1** (uniformity gate) — immediate, ~10 lines, biggest impact
+2. **Change 3** (UDP field) — needed for visibility; coordinate with controller
+3. **Change 2** (on/off contrast) — secondary filter, same code area
+4. **Change 4** (frequency consistency) — requires architectural decision on
+   where it lives
+
+---
+
+## Open Questions
+
+### Uniformity threshold vs K
+
+With K=20, a real weak signal might produce very uneven fold powers due to
+noise fluctuation at low per-fold SNR. If per-fold SNR is ~0 dB, noise
+dominates and fold powers vary widely even with signal present. The fixed
+0.10 threshold may be too aggressive for K=20 at long range.
+
+Options:
+- Lower the threshold (e.g., 0.01) — but then it only catches the most
+  extreme cases
+- Use a K-dependent threshold — e.g., simulate expected uniformity vs
+  per-fold SNR for a given K
+- Use a different statistic — e.g., fraction of folds above the noise
+  floor, rather than min/max ratio
+
+This needs testing against more field data at different ranges and K values.
+
+### What does uniformity look like for real weak signals?
+
+We don't have a confirmed real detection with measured uniformity at long
+range (the Apr-9 K=10 data predates the uniformity metric). Flight 4 at
+2.84 km had uniformity 0.001 on the best headings — but those same headings
+had 2,800+ Hz frequency spread, casting doubt on whether they're real.
+
+**Action needed**: collect uniformity data from a known-range test (tag at
+known position, drone at multiple ranges) to establish the expected
+uniformity vs range/SNR relationship empirically.
+
+### Confirmed vs unconfirmed semantics
+
+Currently `confirmed_status` is a binary mirror of `is_marginal`:
+- `score_ratio >= 1.3` → confirmed_status=1
+- `score_ratio < 1.3` → confirmed_status=0
+
+With the uniformity and contrast gates added, `confirmed_status=0` would
+also cover:
+- score_ratio < 1.3 (current)
+- uniformity < 0.10 (new)
+- contrast_db < 3.0 (new)
+
+The GCS currently only sees confirmed_status as 0 or 1. If it needs to
+distinguish *why* a detection is LOW, additional status bits or a quality
+score would be needed. For now, 0/1 is sufficient — a detection is either
+trustworthy or it isn't.

--- a/detector/CONFIDENCE_PIPELINE.md
+++ b/detector/CONFIDENCE_PIPELINE.md
@@ -9,7 +9,7 @@ The detector uses a layered threshold system. Each layer serves a distinct role:
 
 | Layer | Parameter | Default | Purpose |
 |-------|-----------|---------|---------|
-| 1 | `false_alarm_prob` (pf) | 0.01 | Sets the fundamental noise-floor threshold via EVT |
+| 1 | `false_alarm_prob` (pf) | 0.05 | Sets the fundamental noise-floor threshold via EVT |
 | 2 | `detection_margin` | 0.90 | Lowers the threshold to increase sensitivity |
 | 3 | `confidence_ratio` | 1.30 | Classifies detections as HIGH or LOW confidence |
 | — | `uniformity` | — | Diagnostic metric (not used in classification) |
@@ -169,9 +169,10 @@ uniformity = on_powers.min() / max(on_powers.max(), 1e-30)
 ### Current status
 
 Uniformity is:
-- **Computed** for every detection (line 537 in `pulse_detector.py`)
+- **Computed** for every detection in `pulse_detector.py`
 - **Logged** in the `[FOLDS]` diagnostic line
-- **Stored** in `fold_info` and available to downstream code
+- **Stored** in the in-process `fold_info` dict for local downstream use
+- **NOT sent** in the current UDP packet format, so it is not available to the controller/GCS unless the wire format is extended
 - **NOT used** in the SUBTHRESHOLD/SUPERTHRESHOLD classification
 
 A detection with `uniformity=0.000` will still be classified as `Conf:1` if

--- a/detector/CONFIDENCE_PIPELINE.md
+++ b/detector/CONFIDENCE_PIPELINE.md
@@ -1,0 +1,229 @@
+# Detection Confidence Pipeline
+
+How `false_alarm_prob`, `detection_margin`, `confidence_ratio`, and `uniformity`
+interact to produce detection classifications.
+
+## Overview
+
+The detector uses a layered threshold system. Each layer serves a distinct role:
+
+| Layer | Parameter | Default | Purpose |
+|-------|-----------|---------|---------|
+| 1 | `false_alarm_prob` (pf) | 0.01 | Sets the fundamental noise-floor threshold via EVT |
+| 2 | `detection_margin` | 0.90 | Lowers the threshold to increase sensitivity |
+| 3 | `confidence_ratio` | 1.30 | Classifies detections as HIGH or LOW confidence |
+| — | `uniformity` | — | Diagnostic metric (not used in classification) |
+
+## Pipeline flow
+
+```
+               false_alarm_prob
+                     │
+            ┌────────▼────────┐
+            │  EVT threshold  │  Gumbel quantile from Monte Carlo
+            └────────┬────────┘
+                     │
+            ┌────────▼────────┐
+            │ × detection_    │  0.90 → lower threshold by 10%
+            │   margin        │
+            └────────┬────────┘
+                     │
+            ┌────────▼────────┐
+            │ score_ratio =   │
+            │ score/threshold │
+            └────────┬────────┘
+                     │
+        ┌────────────┼────────────┐
+        │            │            │
+   < 1.0         1.0–1.3       ≥ 1.3
+  No det.     SUBTHRESHOLD   SUPERTHRESHOLD
+              Conf:0 [LOW]     Conf:1
+
+        uniformity ──── logged but not used in decision
+```
+
+---
+
+## Layer 1: EVT threshold from `false_alarm_prob`
+
+The detector generates a per-frequency-bin detection threshold using Extreme Value
+Theory (EVT). This calibrates the threshold to the noise statistics of the actual
+STFT pipeline rather than relying on analytic assumptions.
+
+**How it works:**
+
+1. Run 100 Monte Carlo trials of pure complex Gaussian noise through the full
+   STFT detection pipeline (same window size, overlap, fold structure, and
+   Toeplitz W matrix as real data).
+2. Collect the maximum detection score from each trial.
+3. Fit a Gumbel distribution (extreme value Type I) to these maxima.
+4. Set the threshold at the `(1 - pf)` quantile:
+
+```python
+loc, scale = gumbel_r.fit(max_scores)
+threshold = gumbel_r.ppf(1.0 - pf, loc=loc, scale=scale)
+```
+
+**Effect of `pf`:**
+
+| `pf` | Quantile | Threshold | Sensitivity | False alarm rate |
+|------|----------|-----------|-------------|------------------|
+| 0.10 | 90th     | Lower     | Higher      | Higher           |
+| 0.01 | 99th     | Moderate  | Moderate    | Moderate         |
+| 0.001 | 99.9th  | Higher    | Lower       | Lower            |
+
+The EVT threshold is computed once at startup and cached. It depends on `K`,
+`n_w`, `n_ol`, `nfft`, and the fold structure — but NOT on incoming signal data.
+
+---
+
+## Layer 2: `detection_margin` lowers the threshold
+
+After the EVT threshold is computed, `detection_margin` scales it down:
+
+```python
+base_threshold *= detection_margin   # e.g., 0.90
+```
+
+A margin of 0.90 drops the threshold by 10%. This deliberately allows more
+detections through — including marginal ones near the noise floor that would
+otherwise be missed. The rationale:
+
+- At long range, real tag signals may only barely exceed the EVT threshold.
+- Lowering the threshold captures these weak detections.
+- The two-tier confidence system (Layer 3) then sorts marginal detections
+  from confident ones.
+
+**Without `detection_margin`**, a score_ratio of 1.0 means the signal exactly
+matched the noise-calibrated threshold. With `margin=0.90`, signals that would
+have scored 0.90–1.00 now score above 1.0 and appear as detections.
+
+---
+
+## Layer 3: `confidence_ratio` classifies HIGH vs LOW
+
+Each detection's score is compared to the (margined) threshold to produce a
+score ratio:
+
+```python
+score_ratio = best_scores[b] / max(threshold[b], 1e-30)
+```
+
+This ratio is then compared to `confidence_ratio` (default 1.3):
+
+```python
+is_marginal = score_ratio < confidence_ratio
+det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
+              else DETECTION_STATUS_SUPERTHRESHOLD)
+```
+
+| score_ratio | Classification | `detection_status` | `confirmed_status` | Log tag |
+|-------------|----------------|--------------------|--------------------|---------|
+| ≥ 1.3 | Confident | `SUPERTHRESHOLD` (1) | 1 | *(none)* |
+| 1.0 – 1.3 | Marginal | `SUBTHRESHOLD` (0) | 0 | `[LOW]` |
+| < 1.0 | Below threshold | Not reported | — | — |
+
+The `[LOW]` tag in detector output and `Conf:0` in controller logs both indicate
+a marginal detection — one that only passed because `detection_margin` lowered
+the threshold, and whose score_ratio didn't reach `confidence_ratio`.
+
+### The sensitivity band
+
+The combination of `detection_margin` and `confidence_ratio` creates a
+deliberate sensitivity band between `1.0` and `confidence_ratio`:
+
+```
+          margin lowers              confidence_ratio
+          threshold here             classifies here
+               │                           │
+    ───────────┼───────────────────────────┼──────────▶ score_ratio
+             1.0                         1.3
+         ◄─────── sensitivity band ──────►
+         Detections in this range are
+         flagged [LOW] / Conf:0
+```
+
+**Tuning guidance:**
+- Widen the band (lower margin or raise confidence_ratio) → more LOW detections,
+  fewer missed weak signals, but more noise in results.
+- Narrow the band (raise margin or lower confidence_ratio) → fewer LOW detections,
+  cleaner results, but may miss weak signals at range.
+
+---
+
+## Uniformity: diagnostic metric (not yet in decision path)
+
+Uniformity measures how evenly the detection energy is distributed across
+K folds:
+
+```python
+uniformity = on_powers.min() / max(on_powers.max(), 1e-30)
+```
+
+| Uniformity | Meaning |
+|------------|---------|
+| ~1.0 | Equal power in all folds — consistent pulsed signal |
+| ~0.5 | 2:1 power variation — moderate, possibly real at low SNR |
+| ~0.0 | One fold dominates — spike-driven, likely transient/RFI |
+
+### Current status
+
+Uniformity is:
+- **Computed** for every detection (line 537 in `pulse_detector.py`)
+- **Logged** in the `[FOLDS]` diagnostic line
+- **Stored** in `fold_info` and available to downstream code
+- **NOT used** in the SUBTHRESHOLD/SUPERTHRESHOLD classification
+
+A detection with `uniformity=0.000` will still be classified as `Conf:1` if
+its `score_ratio ≥ 1.3`. This is a known gap.
+
+### Planned use
+
+The on-window uniformity test described in [CROSS_RATE_REJECTION.md](CROSS_RATE_REJECTION.md)
+would add uniformity as a rejection criterion: detections with uniformity below
+a threshold (e.g., 0.10) could be downgraded or rejected. Similarly, the on/off
+contrast test in [CW_REJECTION.md](CW_REJECTION.md) would reject continuous-wave
+interference. Neither test is implemented in the detection decision path yet.
+
+---
+
+## UDP packet fields
+
+Each detection (or no-detection) is sent to the controller as a 96-byte UDP
+packet containing 12 double-precision floats:
+
+| Field | Value (detection) | Value (no-detection) |
+|-------|-------------------|----------------------|
+| `tag_id` | Tag ID | Tag ID |
+| `frequency_hz` | Detected frequency | Expected frequency |
+| `start_time_seconds` | Detection timestamp | Current timestamp |
+| `predict_next_start_seconds` | timestamp + PRI | 0.0 |
+| `snr` | SNR in dB | 0.0 |
+| `stft_score` | score_ratio | Best candidate score_ratio |
+| `group_seq_counter` | Cycle number | Cycle number |
+| `group_ind` | 0 | 0 |
+| `group_snr` | SNR in dB | 0.0 |
+| `detection_status` | 0 (SUB) or 1 (SUPER) | 3 (NO_DETECTION) |
+| `confirmed_status` | 0 or 1 | 0 |
+| `noise_psd` | Noise PSD (W/Hz) | Noise PSD (W/Hz) |
+
+The controller reads `confirmed_status` to decide `Conf:0` vs `Conf:1` in logs.
+
+---
+
+## Interpretation guide
+
+When reviewing field data:
+
+1. **score_ratio ≥ 1.3 + consistent frequency across headings** → high-confidence
+   real detection.
+2. **score_ratio 1.0–1.3 + consistent frequency** → real signal at edge of range,
+   correctly flagged LOW.
+3. **score_ratio ≥ 1.3 + uniformity ≈ 0 + scattered frequencies** → likely
+   transient RFI or interference. The confidence gate passes it, but uniformity
+   and frequency spread indicate it's not a real pulsed tag.
+4. **score_ratio < 1.0** → below threshold, no detection reported.
+
+Frequency consistency across rotation headings is currently the strongest
+post-hoc discriminator between real tags and false positives, since uniformity
+is not yet used in the classification logic.


### PR DESCRIPTION
Documentation from Apr-9 and Apr-11 field testing analysis.

## Files

- **MULTIPATH_ANALYSIS.md** — VHF multipath propagation analysis for aerial collar telemetry at 5+ km range. Covers ground-reflection geometry, how multipath manifests in the K-fold detector and bearing fit, and proposed mitigations (RHCP antenna, targeted dual-altitude re-test, fold-level diagnostics, LM fit weighting improvements).

- **YAGI_ANTENNA_DESIGN.md** — 3-element Yagi antenna design for 146 MHz drone telemetry. Includes dimensions, feedpoint matching, RHCP crossed-dipole variant for multipath rejection, Arrow 146-3 off-the-shelf option, mounting guidelines for 680-class frame, and theoretical pattern LUT for TagTracker.

- **detector/CONFIDENCE_PIPELINE.md** — Documents how `false_alarm_prob`, `detection_margin`, `confidence_ratio`, and `uniformity` interact in the detection classification pipeline. Explains the layered threshold chain and the current gap where uniformity is computed but not used in classification.

- **detector/CONFIDENCE_IMPROVEMENTS.md** — Proposed changes to reduce false positives: uniformity gate (highest priority), on/off contrast test, uniformity in UDP packet, and cross-heading frequency consistency check. Motivated by Apr-11 Flight 2 data where 8/8 Conf:1 detections were all transient/RFI artifacts.