### PR TITLE
Replace uniformity filter with max-fold-fraction confidence diagnostic

### DIFF
--- a/controller/CommandHandler.cpp
+++ b/controller/CommandHandler.cpp
@@ -148,7 +148,7 @@ void CommandHandler::_startDetector(LogFileManager* logFileManager, const Tunnel
     _processes.push_back(detectorProc);
 }
 
-void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio)
+void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio, bool debugDetector)
 {
     int     secondaryChannelIncrement   = secondaryChannel ? 1 : 0;
     int     tagId                       = tagInfo.id + secondaryChannelIncrement;
@@ -185,7 +185,7 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
                                 detectionMargin, confidenceRatio,
                                 cacheDir.c_str(),
                                 k);
-    if (_debugDetector) {
+    if (_debugDetector || debugDetector) {
         commandStr += " --debug";
     }
 
@@ -194,7 +194,7 @@ void CommandHandler::_startPythonDetector(LogFileManager* logFileManager, const 
     // instead of requiring a separate detector process for the second rate.
     if (tagInfo.intra_pulse2_msecs != 0) {
         double tipSecondary = tagInfo.intra_pulse2_msecs / 1000.0;
-        commandStr += formatString(" --tip-secondary %f --min-uniformity 0.25", tipSecondary);
+        commandStr += formatString(" --tip-secondary %f", tipSecondary);
     }
 
     std::string logStem;
@@ -268,6 +268,7 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
         logInfo() << "COMMAND_ID_START_DETECTION:";
         logInfo() << "\tradio_center_frequency_hz:" << startDetection.radio_center_frequency_hz;
         logInfo() << "\tdetection_margin:" << startDetection.detection_margin << " confidence_ratio:" << startDetection.confidence_ratio;
+        logInfo() << "\tdebug_detector:" << startDetection.debug_detector;
         const double centerFrequencyMhz = (double)startDetection.radio_center_frequency_hz / 1000000.0;
 
         std::string sdrPathStatus;
@@ -427,7 +428,8 @@ std::string CommandHandler::_handleStartDetection(const mavlink_tunnel_t& tunnel
             if (startDetection.detection_mode == DETECTION_MODE_PYTHON) {
                 // Python detector handles both rates in a single process via
                 // --tip-secondary, so only launch once per tag.
-                _startPythonDetector(logFileManager, tagInfo, false /* secondaryChannel */, isHFMode, detectionMargin, confidenceRatio);
+                bool debugDet = (startDetection.debug_detector != 0);
+                _startPythonDetector(logFileManager, tagInfo, false /* secondaryChannel */, isHFMode, detectionMargin, confidenceRatio, debugDet);
             } else {
                 _startDetector(logFileManager, tagInfo, false /* secondaryChannel */);
                 if (tagInfo.intra_pulse2_msecs != 0) {
@@ -643,6 +645,7 @@ std::string CommandHandler::_handleStartRotationDetection(const mavlink_tunnel_t
         _rotationStartDetection.detection_mode              = DETECTION_MODE_PYTHON;
         _rotationStartDetection.detection_margin            = rotationInfo.detection_margin;
         _rotationStartDetection.confidence_ratio            = rotationInfo.confidence_ratio;
+        _rotationStartDetection.debug_detector              = rotationInfo.debug_detector;
 
         _inRotation             = true;
         _currentHeadingDeg      = 0;
@@ -657,7 +660,8 @@ std::string CommandHandler::_handleStartRotationDetection(const mavlink_tunnel_t
               << " center_freq_hz:" << rotationInfo.radio_center_frequency_hz
               << " n_slices:" << rotationInfo.n_slices
               << " detection_margin:" << rotationInfo.detection_margin
-              << " confidence_ratio:" << rotationInfo.confidence_ratio;
+              << " confidence_ratio:" << rotationInfo.confidence_ratio
+              << " debug_detector:" << rotationInfo.debug_detector;
 
     return "";
 }

--- a/controller/CommandHandler.h
+++ b/controller/CommandHandler.h
@@ -70,7 +70,7 @@ private:
     bool _handleCleanLogs       (void);
     void _handleTunnelMessage   (const mavlink_message_t& message);
     void _startDetector         (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel);
-    void _startPythonDetector   (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio);
+    void _startPythonDetector   (LogFileManager* logFileManager, const TunnelProtocol::TagInfo_t& tagInfo, bool secondaryChannel, bool isHFMode, double detectionMargin, double confidenceRatio, bool debugDetector);
     std::string _handleStartRotationDetection  (const mavlink_tunnel_t& tunnel);
     std::string _handleStartDetectionAtHeading (const mavlink_tunnel_t& tunnel);
     std::string _handleStopRotationDetection   (const mavlink_tunnel_t& tunnel);

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -51,7 +51,7 @@ det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
 
 ```python
 is_marginal = (score_ratio < confidence_ratio
-               or fold_info['uniformity'] < min_uniformity)
+               or fold_info['max_fold_fraction'] > 0.8)
 det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
               else DETECTION_STATUS_SUPERTHRESHOLD)
 ```
@@ -59,7 +59,7 @@ det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
 ### New CLI argument
 
 ```
---min-uniformity  (default: 0.10)
+No additional CLI argument needed — the 0.8 threshold is built into the detector.
 ```
 
 ### Threshold rationale
@@ -128,7 +128,7 @@ Then in the classification:
 
 ```python
 is_marginal = (score_ratio < confidence_ratio
-               or fold_info['uniformity'] < min_uniformity
+               or fold_info['max_fold_fraction'] > 0.8
                or fold_info['contrast_db'] < min_contrast_db)
 ```
 

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -24,15 +24,16 @@ different frequency. The score_ratio gate cannot catch this.
 
 ---
 
-## Change 1: Uniformity Gate in Detector
+## Change 1: Dominant-Fold Fraction Gate in Detector
 
 **Priority: High — biggest single impact, minimal code change**
 
 ### What
 
-Add a uniformity threshold to the detection decision. Detections with
-uniformity below the threshold are downgraded to SUBTHRESHOLD regardless
-of score_ratio.
+Add a dominant-fold fraction check to the detection decision. Detections
+where a single fold dominates the K-fold score (max_fold_fraction above
+`DOMINANT_FOLD_THRESHOLD`) are downgraded to SUBTHRESHOLD regardless of
+score_ratio.
 
 ### Where
 
@@ -128,7 +129,7 @@ Then in the classification:
 
 ```python
 is_marginal = (score_ratio < confidence_ratio
-               or fold_info['max_fold_fraction'] > 0.8
+               or fold_info['max_fold_fraction'] > DOMINANT_FOLD_THRESHOLD
                or fold_info['contrast_db'] < min_contrast_db)
 ```
 

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -51,7 +51,7 @@ det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
 
 ```python
 is_marginal = (score_ratio < confidence_ratio
-               or fold_info['max_fold_fraction'] > 0.8)
+               or fold_info['max_fold_fraction'] > DOMINANT_FOLD_THRESHOLD)
 det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
               else DETECTION_STATUS_SUPERTHRESHOLD)
 ```

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -80,10 +80,11 @@ heuristic and only flags genuine single-transient false alarms.
 
 ### Impact on existing detections
 
-Reviewing all field data:
+Reviewing all field data (uniformity values are from the legacy `min/max`
+metric, now replaced by `max_fold_fraction`):
 
-| Flight | Real signal? | Uniformity range | Affected? |
-|--------|-------------|------------------|-----------|
+| Flight | Real signal? | Uniformity (legacy) | Affected? |
+|--------|-------------|----------------------|-----------|
 | Apr-9 K=10 (4 km) | Yes | Not available (pre-uniformity) | No |
 | Apr-11 Flight 2 (5.75 km) | No — RFI | 0.000–0.004 | **Yes — all 8 downgraded** |
 | Apr-11 Flight 3 (7.03 km) | Marginal | 0.001–0.029 | Some at 0.001–0.004 |

--- a/detector/CONFIDENCE_IMPROVEMENTS.md
+++ b/detector/CONFIDENCE_IMPROVEMENTS.md
@@ -56,26 +56,26 @@ det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
               else DETECTION_STATUS_SUPERTHRESHOLD)
 ```
 
-### New CLI argument
+### Threshold
 
-```
-No additional CLI argument needed — the 0.8 threshold is built into the detector.
-```
+No CLI argument — the `DOMINANT_FOLD_THRESHOLD` (0.8) constant is built
+into the detector.
 
-### Threshold rationale
+### Max-fold-fraction rationale
 
-| Uniformity | Meaning | Action |
-|------------|---------|--------|
-| < 0.10 | ≤1 fold dominates — transient/spike | Downgrade to LOW |
-| 0.10–0.25 | Marginal — possible weak signal with fading | Pass (conservative) |
-| > 0.25 | Multiple folds contributing — consistent pulse train | Pass |
+`max_fold_fraction = max(fold_powers) / sum(fold_powers)`.  Higher values
+are worse (a single fold dominates the score).
 
-The 0.10 starting point is deliberately conservative. It only rejects cases
-where one fold has ≥10× the power of the weakest — clearly not a periodic
-pulse. This would have rejected all 8 Flight 2 detections (uniformity
-0.000–0.004) without affecting any Flight 4 real detections.
+| max_fold_fraction | Meaning | Action |
+|-------------------|---------|--------|
+| > 0.8 | Single fold dominates — likely transient/spike | Downgrade to SUBTHRESHOLD |
+| 0.2–0.8 | Some variation across folds — normal for weak signals | Pass |
+| ~1/K | Uniform power across all folds — ideal pulse train | Pass |
 
-See [CROSS_RATE_REJECTION.md](CROSS_RATE_REJECTION.md) for the full design.
+This replaces the old `min/max` uniformity metric which was fundamentally
+broken at high SNR (all detections had U≈0.01 and were rejected).  The
+fraction-of-sum approach matches uavrt_detection's `selectpeakindex`
+heuristic and only flags genuine single-transient false alarms.
 
 ### Impact on existing detections
 

--- a/detector/PYTHON_VS_UAVRT_COMPARISON.md
+++ b/detector/PYTHON_VS_UAVRT_COMPARISON.md
@@ -221,7 +221,6 @@ Python resets more aggressively on gaps (30 ms vs 1.0 s for zero-fill threshold)
 | `--detection-margin` | 0.90 | `startDetection.detection_margin` |
 | `--confidence-ratio` | 1.3 | `startDetection.confidence_ratio` |
 | `--tip-secondary` | None | `intra_pulse2_msecs / 1000` (if ≠ 0) |
-| `--min-uniformity` | 0.0 | 0.25 (when tip-secondary active) |
 | `--tag-id` | 0 | `tagInfo.id` |
 | `--freq` | 0 | `tagInfo.frequency_hz` |
 

--- a/detector/RATE_SWITCH_DETECTOR_DESIGN.md
+++ b/detector/RATE_SWITCH_DETECTOR_DESIGN.md
@@ -34,16 +34,15 @@ For each hypothesis, the detector:
 
 The best score across all hypotheses and start positions is compared against an EVT-derived threshold (calibrated over the full hypothesis bank to control false alarm rate).
 
-## Uniformity Filter
+## Fold Quality Diagnostic
 
-After thresholding, a uniformity check rejects detections where pulse power is concentrated in a subset of folds (cross-rate leakage). Uniformity = min fold power / max fold power. Reject if below `min_uniformity` (default 0.25).
+After thresholding, a max-fold-fraction diagnostic measures whether pulse power is concentrated in a single fold (transient/spike). `max_fold_fraction = max(fold_powers) / sum(fold_powers)`. Values > 0.8 indicate a single transient dominates the score. This is used to downgrade confidence, not to discard detections (matching uavrt_detection's `selectpeakindex` heuristic).
 
-For a correctly matched hypothesis, all K folds land on real pulses, so uniformity is high. For a mismatched hypothesis, some folds land on noise, giving near-zero uniformity.
+For a correctly matched hypothesis, all K folds land on real pulses, so power is spread across folds (low fraction). For a transient, one fold dominates (high fraction).
 
 ## Configuration
 
 - `--tip-secondary <seconds>`: enables multi-hypothesis mode with the second rate.
-- `--min-uniformity <float>`: uniformity threshold (controller passes 0.25 for dual-rate).
 - If `--tip-secondary` is absent, behavior matches the single-rate detector exactly.
 
 ## Pulse Reporting Pipeline (Python Detector → Tag Tracker GCS)
@@ -156,10 +155,10 @@ The IQ simulator (`simulator/iq_simulator.py`) supports rate switching:
 Complete:
 1. Hypothesis generation (`build_hypothesis_indices`) and multi-hypothesis fold (`fold_multi_hypothesis`) in `pulse_detector.py`.
 2. EVT threshold calibrated over full hypothesis bank.
-3. Uniformity check applied post-threshold, gated by `--min-uniformity`.
+3. Max-fold-fraction diagnostic computed per detection for confidence downgrade.
 4. Detection logs include hypothesis label (e.g. `hyp=A_to_B_c2`).
 5. UDP reporting includes `group_ind` derived from hypothesis label.
-6. Controller launches a single detector process per tag; passes `--tip-secondary` and `--min-uniformity 0.25` when dual-rate.
+6. Controller launches a single detector process per tag; passes `--tip-secondary` when dual-rate.
 
 ## Tests
 

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -41,6 +41,7 @@ from scipy.stats import gumbel_r
 
 K = 5  # Default fold count, overridden by --k
 FOLD_LOCAL_RADIUS = 1  # Use local max over [idx-r, ..., idx+r] per fold
+OCCAM_MARGIN = 0.05    # Prefer pure hypothesis if within 5% of switch winner
 
 # Detection status values (mirrors TunnelProtocol.h detection_status field)
 DETECTION_STATUS_SUBTHRESHOLD  = 0  # Subthreshold pulse
@@ -68,7 +69,7 @@ class Detection(NamedTuple):
     stft_score: float       # Fold score / PSD scale
     score_ratio: float      # Fold score / threshold (>1 = above threshold)
     hyp_label: str          # Winning hypothesis label (e.g. "A", "A_to_B_c2")
-    fold_info: dict         # {'uniformity': float, 'fold_snrs': list[float]}
+    fold_info: dict         # {'max_fold_fraction': float, 'fold_snrs': list[float]}
 
 
 def hyp_label_to_group_ind(label, K=5):
@@ -330,6 +331,12 @@ def build_hypothesis_indices(N_A, K, n_time, N_B=None):
 def fold_multi_hypothesis(power, hypotheses):
     """Fold power spectrogram across all hypotheses and return best per bin.
 
+    Applies an Occam preference: if a switch hypothesis wins but the
+    corresponding pure hypothesis (A or B, matching the switch's last rate)
+    scores within OCCAM_MARGIN of the winner, the pure hypothesis is
+    preferred.  This avoids spurious switch labels caused by sub-window
+    phase alignment at high SNR.
+
     Args:
         power:      (n_freq, n_time) float32 power spectrogram.
         hypotheses: list from build_hypothesis_indices().
@@ -345,6 +352,9 @@ def fold_multi_hypothesis(power, hypotheses):
     best_labels = np.empty(n_freq, dtype=object)
     best_labels[:] = ""
 
+    # Track pure-hypothesis scores for Occam preference
+    pure_scores = {}   # label -> (scores_array, offsets_array)
+
     for label, pulse_idx in hypotheses:
         # fold_scores shape: (n_freq, search_range)
         fold_scores = _compute_fold_scores(power, pulse_idx,
@@ -352,33 +362,41 @@ def fold_multi_hypothesis(power, hypotheses):
         hyp_best = np.max(fold_scores, axis=1)
         hyp_offsets = np.argmax(fold_scores, axis=1)
 
+        if label in ('A', 'B'):
+            pure_scores[label] = (hyp_best.copy(), hyp_offsets.copy())
+
         improved = hyp_best > best_scores
         best_scores[improved] = hyp_best[improved]
         best_offsets[improved] = hyp_offsets[improved]
         best_labels[improved] = label
 
+    # Occam preference: for bins where a switch hypothesis won, check if the
+    # corresponding pure hypothesis scored within OCCAM_MARGIN.  Switch
+    # hypotheses have extra degrees of freedom (the change point), so they
+    # can overfit sub-window alignment at high SNR.
+    if pure_scores:
+        for b in range(n_freq):
+            lbl = best_labels[b]
+            if lbl in ('A', 'B', ''):
+                continue  # already pure or empty
+            # Determine which pure hypothesis corresponds to this switch's
+            # last rate (the one used for next-pulse prediction).
+            if lbl.startswith('A_to_B'):
+                pure_lbl = 'B'
+            elif lbl.startswith('B_to_A'):
+                pure_lbl = 'A'
+            else:
+                continue
+            if pure_lbl not in pure_scores:
+                continue
+            pure_sc, pure_off = pure_scores[pure_lbl]
+            if best_scores[b] > 0 and pure_sc[b] >= best_scores[b] * (1.0 - OCCAM_MARGIN):
+                best_scores[b] = pure_sc[b]
+                best_offsets[b] = pure_off[b]
+                best_labels[b] = pure_lbl
+
     return best_scores, best_offsets, best_labels
 
-
-def uniformity_check(power, freq_bin, pulse_indices, U_min):
-    """Check pulse-window power uniformity for a single detection.
-
-    Args:
-        power:         (n_freq, n_time) power spectrogram.
-        freq_bin:      int — frequency bin index of the detection.
-        pulse_indices: 1-D array of K time-window indices for the detection.
-        U_min:         Minimum acceptable uniformity ratio.
-
-    Returns:
-        (U, passed) where U = min/max pulse power and passed = (U >= U_min).
-    """
-    powers = _local_peak_powers_1d(power[freq_bin], pulse_indices,
-                                   local_radius=FOLD_LOCAL_RADIUS)
-    p_max = np.max(powers)
-    if p_max <= 0:
-        return 0.0, False
-    U = float(np.min(powers) / p_max)
-    return U, U >= U_min
 
 
 def _compute_fold_scores(power, pulse_idx, local_radius=0):
@@ -676,14 +694,20 @@ def save_evt_cache(cache_dir, N_A, K, mu, sigma, N_B=None,
 def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
                 evt_threshold_cache, fold_offsets=None, W=None, Wf=None,
                 debug=False, detection_margin=0.90,
-                hypotheses=None, N_B=None, min_uniformity=0.0,
+                hypotheses=None, N_B=None,
                 N_A_exact=None, N_B_exact=None):
     """Fold power spectrogram and detect pulses.
 
     Supports both single-rate and multi-hypothesis rate-switch detection.
-    When *hypotheses* is provided, folds across all hypotheses and applies
-    an optional uniformity filter.  When hypotheses is None, falls back to
-    fold_offsets-based (or basic N-stride) single-rate fold.
+    When *hypotheses* is provided, folds across all hypotheses.  When
+    hypotheses is None, falls back to fold_offsets-based (or basic
+    N-stride) single-rate fold.
+
+    Each detection includes a ``max_fold_fraction`` diagnostic — the
+    largest single fold's fraction of the total K-fold score.  This is
+    used by the caller to downgrade confidence (not to discard
+    detections).  A value > 0.8 indicates a single transient dominates
+    the score (matching uavrt_detection's ``selectpeakindex`` heuristic).
 
     Args:
         power:               (n_freq, n_time) float32 power spectrogram.
@@ -701,7 +725,6 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         hypotheses:          List from build_hypothesis_indices() (or None).
         N_B:                 Secondary PRI spacing (for EVT cache key; None
                              if single-rate).
-        min_uniformity:      Minimum U_h to accept a detection (0 = disabled).
         N_A_exact:           Fractional PRI for rate A (for EVT cache key).
                              Defaults to N if not provided.
         N_B_exact:           Fractional PRI for rate B (for EVT cache key).
@@ -711,8 +734,9 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         (detections, noise_psd, best_candidate) where:
           detections: list of (freq_hz, snr_db, offset, noise_psd, stft_score,
                       score_ratio, hyp_label, fold_info) sorted by SNR
-                      descending.  fold_info is a dict with 'uniformity'
-                      (float) and 'fold_snrs' (list of per-fold SNRs in dB).
+                      descending.  fold_info is a dict with
+                      'max_fold_fraction' (float) and 'fold_snrs'
+                      (list of per-fold SNRs in dB).
           noise_psd:  float — median noise PSD across frequency bins when no
                       detections are found; None when detections are present;
                       NaN on early-exit error paths (insufficient data).
@@ -866,7 +890,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
 
         # Compute per-hypothesis scores at this frequency bin
         hyp_diag = []
-        hyp_detail = []  # (label, ratio, offset, pulse_windows, fold_powers, U)
+        hyp_detail = []  # (label, ratio, offset, pulse_windows, fold_powers, mff)
         for label, pidx in hypotheses:
             fold_scores_h = _compute_fold_scores(
                 power[diag_bin:diag_bin + 1, :], pidx,
@@ -875,22 +899,22 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
             h_best_offset = int(np.argmax(fold_scores_h))
             h_ratio = h_best_score / max(float(threshold[diag_bin]), 1e-30)
 
-            # Compute uniformity for this hypothesis at its best offset
+            # Compute max_fold_fraction for this hypothesis at its best offset
             on_idx = pidx[h_best_offset]
             on_powers = _local_peak_powers_1d(
                 power[diag_bin], on_idx, local_radius=FOLD_LOCAL_RADIUS)
-            p_max = float(np.max(on_powers))
-            U = float(np.min(on_powers) / max(p_max, 1e-30))
+            p_sum = float(np.sum(on_powers))
+            mff = float(np.max(on_powers) / max(p_sum, 1e-30))
 
-            hyp_diag.append((label, h_ratio, U))
+            hyp_diag.append((label, h_ratio, mff))
             hyp_detail.append((label, h_ratio, h_best_offset, on_idx.tolist(),
-                               on_powers.tolist(), U))
+                               on_powers.tolist(), mff))
 
         # Sort by score ratio descending and show all hypotheses.
         hyp_diag.sort(key=lambda x: -x[1])
         top_str = '  '.join(
-            f'{lbl}:{rat:.1f}/U{u:.2f}{"*" if u < min_uniformity and min_uniformity > 0 else ""}'
-            for lbl, rat, u in hyp_diag
+            f'{lbl}:{rat:.1f}/F{mff:.2f}{"*" if mff > 0.8 else ""}'
+            for lbl, rat, mff in hyp_diag
         )
         n_above = len(det_bins)
         print(f'  [HYP] best_bin={diag_bin} winner={diag_label} '
@@ -900,12 +924,12 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         # Show per-fold SNR vectors for every hypothesis so we can inspect
         # which specific folds are weak/strong across the full bank.
         hyp_detail.sort(key=lambda x: -x[1])  # sort by score ratio
-        for lbl, rat, off, widx, fpow, U in hyp_detail:
+        for lbl, rat, off, widx, fpow, mff in hyp_detail:
             noise_at_bin = float(noise_power[diag_bin])
             fold_snrs = [f'{10*np.log10(p/noise_at_bin):.1f}' if p > 0
                          else '-inf' for p in fpow]
             print(f'  [HYP detail] {lbl} ratio={rat:.1f} t0={off} wins={widx} '
-                  f'n_time={n_time} U={U:.4f} '
+                  f'n_time={n_time} F={mff:.4f} '
                   f'fold_pwr=[{", ".join(f"{p:.3e}" for p in fpow)}] '
                   f'fold_snr=[{", ".join(fold_snrs)}] dB',
                   flush=True)
@@ -914,7 +938,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         median_noise_psd = float(np.median(noise_power) / psd_scale)
         return [], median_noise_psd, best_cand
 
-    # --- Build detection results with uniformity filter ---
+    # --- Build detection results ---
     # Build a lookup from hypothesis label to its pulse_idx matrix so we can
     # recover the exact pulse window indices for the winning hypothesis.
     hyp_lookup = {}
@@ -923,31 +947,9 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
             hyp_lookup[label] = pidx
 
     results = []
-    uniformity_reject_count = 0
     for b in det_bins:
         label = str(best_labels[b])
         offset = int(best_offsets[b])
-
-        # Uniformity filter: check that pulse windows have roughly equal power.
-        # In multi-hypothesis mode, use the winning hypothesis pulse_idx matrix.
-        # In legacy single-rate mode, fall back to the local pulse_idx matrix.
-        if min_uniformity > 0:
-            pidx_matrix = None
-            if label in hyp_lookup:
-                pidx_matrix = hyp_lookup[label]
-            elif not hypotheses:
-                pidx_matrix = pulse_idx
-
-            if pidx_matrix is not None and offset < pidx_matrix.shape[0]:
-                pulse_windows = pidx_matrix[offset]
-                U, passed = uniformity_check(power, b, pulse_windows,
-                                             min_uniformity)
-                if not passed:
-                    uniformity_reject_count += 1
-                    if debug:
-                        print(f'[DEBUG UNIFORMITY] bin={b} hyp={label} '
-                              f'U={U:.3f} < {min_uniformity:.3f} — rejected')
-                    continue
 
         snr_db = 10.0 * np.log10(best_scores[b] / noise_power[b])
         # Score-to-threshold ratio: how far above threshold this detection is.
@@ -964,8 +966,10 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         on_powers = _local_peak_powers_1d(
             power[b], on_idx, local_radius=FOLD_LOCAL_RADIUS)
         fold_snrs_db = (10.0 * np.log10(on_powers / noise_power[b])).tolist()
-        uniformity = float(on_powers.min() / max(on_powers.max(), 1e-30))
-        fold_info = {'uniformity': uniformity, 'fold_snrs': fold_snrs_db}
+        p_sum = float(np.sum(on_powers))
+        max_fold_fraction = float(np.max(on_powers) / max(p_sum, 1e-30))
+        fold_info = {'max_fold_fraction': max_fold_fraction,
+                     'fold_snrs': fold_snrs_db}
         results.append(Detection(
             freq_hz=freq_axis[b], snr_db=snr_db, offset=offset,
             noise_psd=float(noise_power[b] / psd_scale),
@@ -988,9 +992,6 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
             break
 
     if len(merged) == 0:
-        if uniformity_reject_count > 0:
-            print(f'  [HYP] uniformity rejected {uniformity_reject_count}/{len(det_bins)} '
-                  f'detection bins (U_min={min_uniformity:.2f})', flush=True)
         median_noise_psd = float(np.median(noise_power) / psd_scale)
         return [], median_noise_psd, best_cand
 
@@ -1040,10 +1041,6 @@ def main():
                     help='Secondary inter-pulse interval in seconds. '
                          'Enables multi-hypothesis rate-switch detection. '
                          'Omit to use single-rate mode (backwards compatible).')
-    ap.add_argument('--min-uniformity', type=float, default=0.0,
-                    help='Minimum pulse-window uniformity ratio to accept a '
-                         'detection (default: 0, disabled). Set > 0 to enable '
-                         '(e.g. 0.25). Recommended for multi-hypothesis mode.')
     ap.add_argument('--warmup-seconds', type=float, default=5.0,
                     help='Seconds of initial IQ data to discard before '
                          'detection starts (default: 5.0).')
@@ -1173,8 +1170,6 @@ def main():
           f'(~{fa_per_hour:.2f} false alarms/hour)')
     print(f'  Det margin      {args.detection_margin:.2f}')
     print(f'  Conf ratio      {args.confidence_ratio:.2f}')
-    if args.min_uniformity > 0:
-        print(f'  Uniformity      U_min={args.min_uniformity:.2f}')
     print(f'  UDP port        {args.port}')
     print(f'  Warmup discard  {args.warmup_seconds:.1f} s')
     if args.center_freq > 0:
@@ -1431,7 +1426,6 @@ def main():
                                      detection_margin=args.detection_margin,
                                      hypotheses=rate_switch_hypotheses,
                                      N_B=N_B,
-                                     min_uniformity=args.min_uniformity,
                                      N_A_exact=N_exact,
                                      N_B_exact=N_B_exact)
             proc_ms = (time.monotonic() - t0) * 1000.0
@@ -1469,10 +1463,20 @@ def main():
                 tip_secondary = getattr(args, 'tip_secondary', None)
 
                 for det in detections:
-                    is_marginal = det.score_ratio < confidence_ratio
+                    # Fold quality: if any single fold carries >80% of the
+                    # total score, this is likely a transient (not a real
+                    # pulse train).  Matches uavrt_detection's
+                    # selectpeakindex heuristic.  Downgrade to SUBTHRESHOLD
+                    # rather than discarding.
+                    has_dominant_fold = det.fold_info['max_fold_fraction'] > 0.8
+                    is_marginal = det.score_ratio < confidence_ratio or has_dominant_fold
                     det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
                                   else DETECTION_STATUS_SUPERTHRESHOLD)
-                    confidence_flag = '  [LOW]' if is_marginal else ''
+                    confidence_flag = ''
+                    if has_dominant_fold:
+                        confidence_flag = '  [DOMINANT_FOLD]'
+                    elif det.score_ratio < confidence_ratio:
+                        confidence_flag = '  [LOW]'
                     hyp_flag = f'  hyp={det.hyp_label}' if det.hyp_label != 'A' else ''
 
                     # Map hypothesis label → group_ind encoding and
@@ -1523,7 +1527,7 @@ def main():
                               f'{proc_ms:.0f} ms{delta_str}{gap_flag}{confidence_flag}{hyp_flag}')
                     fold_snrs_str = ', '.join(f'{s:.1f}' for s in det.fold_info['fold_snrs'])
                     print(f'  [FOLDS] score_ratio={det.score_ratio:.3f}  '
-                          f'uniformity={det.fold_info["uniformity"]:.3f}  '
+                          f'max_fold_frac={det.fold_info["max_fold_fraction"]:.3f}  '
                           f'per_fold_snr=[{fold_snrs_str}] dB')
             else:
                 # Send a no-detection report so the controller/GCS knows

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -368,7 +368,7 @@ def fold_multi_hypothesis(power, hypotheses):
         hyp_offsets = np.argmax(fold_scores, axis=1)
 
         if label in ('A', 'B'):
-            pure_scores[label] = (hyp_best.copy(), hyp_offsets.copy())
+            pure_scores[label] = (hyp_best, hyp_offsets)
 
         improved = hyp_best > best_scores
         best_scores[improved] = hyp_best[improved]
@@ -711,8 +711,8 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     Each detection includes a ``max_fold_fraction`` diagnostic — the
     largest single fold's fraction of the total K-fold score.  This is
     used by the caller to downgrade confidence (not to discard
-    detections).  A value > 0.8 indicates a single transient dominates
-    the score (see ``DOMINANT_FOLD_THRESHOLD``).
+    detections).  A value above ``DOMINANT_FOLD_THRESHOLD`` indicates a
+    single transient dominates the score.
 
     Args:
         power:               (n_freq, n_time) float32 power spectrogram.

--- a/detector/pulse_detector.py
+++ b/detector/pulse_detector.py
@@ -59,6 +59,11 @@ DETECTION_STATUS_NO_DETECTION   = 3  # Searched but no pulse found
 HYP_GROUP_IND_A = 0
 HYP_GROUP_IND_B = 1
 
+# If any single fold carries more than this fraction of the total K-fold
+# score, the detection is likely a transient rather than a real pulse train.
+# Matches uavrt_detection's selectpeakindex heuristic.
+DOMINANT_FOLD_THRESHOLD = 0.8
+
 
 class Detection(NamedTuple):
     """Single pulse detection result from fold_detect."""
@@ -707,7 +712,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
     largest single fold's fraction of the total K-fold score.  This is
     used by the caller to downgrade confidence (not to discard
     detections).  A value > 0.8 indicates a single transient dominates
-    the score (matching uavrt_detection's ``selectpeakindex`` heuristic).
+    the score (see ``DOMINANT_FOLD_THRESHOLD``).
 
     Args:
         power:               (n_freq, n_time) float32 power spectrogram.
@@ -913,7 +918,7 @@ def fold_detect(power, N, pf, Fs, nfft, n_w, n_ol, samples_needed,
         # Sort by score ratio descending and show all hypotheses.
         hyp_diag.sort(key=lambda x: -x[1])
         top_str = '  '.join(
-            f'{lbl}:{rat:.1f}/F{mff:.2f}{"*" if mff > 0.8 else ""}'
+            f'{lbl}:{rat:.1f}/F{mff:.2f}{"*" if mff > DOMINANT_FOLD_THRESHOLD else ""}'
             for lbl, rat, mff in hyp_diag
         )
         n_above = len(det_bins)
@@ -1468,7 +1473,7 @@ def main():
                     # pulse train).  Matches uavrt_detection's
                     # selectpeakindex heuristic.  Downgrade to SUBTHRESHOLD
                     # rather than discarding.
-                    has_dominant_fold = det.fold_info['max_fold_fraction'] > 0.8
+                    has_dominant_fold = det.fold_info['max_fold_fraction'] > DOMINANT_FOLD_THRESHOLD
                     is_marginal = det.score_ratio < confidence_ratio or has_dominant_fold
                     det_status = (DETECTION_STATUS_SUBTHRESHOLD if is_marginal
                                   else DETECTION_STATUS_SUPERTHRESHOLD)

--- a/detector/tests/test_end_to_end.py
+++ b/detector/tests/test_end_to_end.py
@@ -84,8 +84,7 @@ def _generate_segment(K: int, snr_db: float, freq_offset_hz: float = 0.0,
 
 def _run_detect(K: int, snr_db: float, freq_offset_hz: float = 0.0,
                 tip: float = TIP_REST, seed: int = 42,
-                detection_margin: float = 0.90,
-                min_uniformity: float = 0.0):
+                detection_margin: float = 0.90):
     """Full pipeline: generate IQ → STFT → fold_detect. Returns fold_detect output."""
     old_K = pulse_detector.K
     pulse_detector.K = K
@@ -106,7 +105,6 @@ def _run_detect(K: int, snr_db: float, freq_offset_hz: float = 0.0,
             fold_offsets=fo,
             W=W, Wf=Wf,
             detection_margin=detection_margin,
-            min_uniformity=min_uniformity,
         )
     finally:
         pulse_detector.K = old_K
@@ -153,7 +151,7 @@ class TestSingleRateK5:
     def test_fold_info_present(self):
         detections, _, _ = _run_detect(self.K, snr_db=25.0)
         assert len(detections) >= 1
-        assert 'uniformity' in detections[0].fold_info
+        assert 'max_fold_fraction' in detections[0].fold_info
         assert 'fold_snrs' in detections[0].fold_info
         assert len(detections[0].fold_info['fold_snrs']) == self.K
 
@@ -230,11 +228,11 @@ class TestSingleRateK20:
         bin_width = FS / NFFT
         assert abs(wrapped_diff - (-300.0)) < 2 * bin_width
 
-    def test_uniformity_filter(self):
-        """Strong signal should pass a moderate uniformity filter."""
-        detections, _, _ = _run_detect(self.K, snr_db=25.0, min_uniformity=0.25)
+    def test_max_fold_fraction_present(self):
+        """Strong signal should have a reasonable max_fold_fraction."""
+        detections, _, _ = _run_detect(self.K, snr_db=25.0)
         assert len(detections) >= 1
-        assert detections[0].fold_info['uniformity'] >= 0.25
+        assert 0.0 < detections[0].fold_info['max_fold_fraction'] <= 1.0
 
 
 # ===================================================================
@@ -298,8 +296,7 @@ def _run_detect_rate_switch(K: int, snr_db: float, change_point: int,
                             direction: str = 'A_to_B',
                             freq_offset_hz: float = 0.0,
                             seed: int = 42,
-                            detection_margin: float = 0.90,
-                            min_uniformity: float = 0.0):
+                            detection_margin: float = 0.90):
     """Full pipeline with multi-hypothesis fold_detect."""
     old_K = pulse_detector.K
     pulse_detector.K = K
@@ -320,7 +317,6 @@ def _run_detect_rate_switch(K: int, snr_db: float, change_point: int,
             W=W, Wf=Wf,
             detection_margin=detection_margin,
             hypotheses=hyps, N_B=N_MOVE,
-            min_uniformity=min_uniformity,
         )
     finally:
         pulse_detector.K = old_K
@@ -425,12 +421,12 @@ class TestRateSwitchK5:
         assert len(detections) == 0
         assert np.isfinite(noise_psd)
 
-    def test_uniformity_passes_correct_switch(self):
-        """Correct switch hypothesis should pass the uniformity filter."""
+    def test_max_fold_fraction_correct_switch(self):
+        """Correct switch hypothesis should have a reasonable max_fold_fraction."""
         detections, _, _ = _run_detect_rate_switch(
-            self.K, snr_db=25.0, change_point=2, min_uniformity=0.25)
+            self.K, snr_db=25.0, change_point=2)
         assert len(detections) >= 1
-        assert detections[0].fold_info['uniformity'] >= 0.25
+        assert 0.0 < detections[0].fold_info['max_fold_fraction'] <= 1.0
 
     def test_fold_info_has_k_entries(self):
         """Rate-switch detection fold_info should contain K per-fold SNRs."""

--- a/detector/tests/test_rate_switch.py
+++ b/detector/tests/test_rate_switch.py
@@ -298,20 +298,25 @@ class TestFoldMultiHypothesis:
         for k in range(K):
             power[signal_bin, t0 + k * N_B] += 80.0
 
-        # Also inject a slightly stronger signal at A_to_B_c1 positions
-        # at bin 3 — the switch score will be just marginally higher
-        # than pure B.
-        t0_sw = 5
-        sw_positions = [t0_sw, t0_sw + N_A, t0_sw + N_A + N_B,
-                        t0_sw + N_A + 2 * N_B, t0_sw + N_A + 3 * N_B]
-        for p in sw_positions:
-            power[3, p] += 80.0
+        # Inject a pure-B signal at bin 3 as well, then add a tiny bump
+        # at the one A-rate position that A_to_B_c1 sees but pure-B doesn't.
+        # This makes A_to_B_c1 barely beat pure B (within OCCAM_MARGIN),
+        # so Occam should override and select "B".
+        occam_bin = 3
+        t0_b = 5
+        for k in range(K):
+            power[occam_bin, t0_b + k * N_B] += 80.0
+        # A_to_B_c1 first fold is at A-rate offset from t0.
+        # Add a small bump so the switch scores ~2% higher than pure B.
+        power[occam_bin, t0_b + N_A] += 2.0
 
         hyps = build_hypothesis_indices(N_A, K, n_time, N_B=N_B)
         _, _, best_labels = fold_multi_hypothesis(power, hyps)
 
         # Bin 2: pure B signal → must be labeled "B" (no switch)
         assert best_labels[signal_bin] == "B"
+        # Bin 3: marginal switch competition → Occam prefers pure B
+        assert best_labels[occam_bin] == "B"
 
     def test_occam_does_not_override_clear_switch(self):
         """When a switch hypothesis wins by more than OCCAM_MARGIN,

--- a/detector/tests/test_rate_switch.py
+++ b/detector/tests/test_rate_switch.py
@@ -350,7 +350,7 @@ class TestFoldMultiHypothesis:
 # ---------------------------------------------------------------------------
 
 class TestMaxFoldFraction:
-    """Verify that max_fold_fraction is correctly computed in fold_info."""
+    """Verify the dominant-fold ratio used to derive max_fold_fraction from on_powers."""
 
     def test_uniform_signal_low_fraction(self):
         """Equal-power folds should produce max_fold_fraction = 1/K."""

--- a/detector/tests/test_rate_switch.py
+++ b/detector/tests/test_rate_switch.py
@@ -3,7 +3,7 @@
 Tests cover:
   - Hypothesis index generation (pure and switch schedules)
   - Multi-hypothesis fold correctness
-  - Uniformity filter
+  - Fold quality (max_fold_fraction / dominant-fold check)
   - Segment length computation
   - EVT cache naming isolation
   - End-to-end fold_detect with synthetic signals
@@ -22,6 +22,7 @@ from pulse_detector import (
     FOLD_LOCAL_RADIUS,
     HYP_GROUP_IND_A,
     HYP_GROUP_IND_B,
+    OCCAM_MARGIN,
     build_hypothesis_indices,
     build_weighting_matrix,
     compute_segment_samples,
@@ -29,7 +30,6 @@ from pulse_detector import (
     fold_detect,
     fold_multi_hypothesis,
     hyp_label_to_group_ind,
-    uniformity_check,
     _evt_cache_path,
     load_evt_cache,
     save_evt_cache,
@@ -282,54 +282,95 @@ class TestFoldMultiHypothesis:
         np.testing.assert_allclose(best_scores, expected_best, rtol=1e-5)
         np.testing.assert_array_equal(best_offsets, expected_offsets)
 
+    def test_occam_prefers_pure_when_close(self):
+        """When a switch hypothesis barely beats a pure hypothesis,
+        Occam preference should select the pure one."""
+        N_A, N_B = 50, 30
+        n_time = 500
+        n_freq = 5
+        rng = np.random.RandomState(88)
+
+        power = rng.exponential(1.0, (n_freq, n_time)).astype(np.float32)
+
+        # Inject a pure-B signal at bin 2
+        signal_bin = 2
+        t0 = 10
+        for k in range(K):
+            power[signal_bin, t0 + k * N_B] += 80.0
+
+        # Also inject a slightly stronger signal at A_to_B_c1 positions
+        # at bin 3 — the switch score will be just marginally higher
+        # than pure B.
+        t0_sw = 5
+        sw_positions = [t0_sw, t0_sw + N_A, t0_sw + N_A + N_B,
+                        t0_sw + N_A + 2 * N_B, t0_sw + N_A + 3 * N_B]
+        for p in sw_positions:
+            power[3, p] += 80.0
+
+        hyps = build_hypothesis_indices(N_A, K, n_time, N_B=N_B)
+        _, _, best_labels = fold_multi_hypothesis(power, hyps)
+
+        # Bin 2: pure B signal → must be labeled "B" (no switch)
+        assert best_labels[signal_bin] == "B"
+
+    def test_occam_does_not_override_clear_switch(self):
+        """When a switch hypothesis wins by more than OCCAM_MARGIN,
+        the switch label should be preserved."""
+        N_A, N_B = 50, 30
+        n_time = 500
+        n_freq = 5
+        rng = np.random.RandomState(42)
+
+        power = rng.exponential(1.0, (n_freq, n_time)).astype(np.float32)
+
+        # Inject a clear A_to_B_c2 signal at bin 3
+        signal_bin = 3
+        signal_power = 100.0
+        t0 = 5
+        positions = [t0, t0 + N_A, t0 + 2*N_A,
+                     t0 + 2*N_A + N_B, t0 + 2*N_A + 2*N_B]
+        for p in positions:
+            power[signal_bin, p] += signal_power
+
+        hyps = build_hypothesis_indices(N_A, K, n_time, N_B=N_B)
+        _, _, best_labels = fold_multi_hypothesis(power, hyps)
+
+        # The switch signal is genuinely better than pure B at this bin,
+        # so Occam should NOT override it.
+        assert best_labels[signal_bin] == "A_to_B_c2"
+
 
 # ---------------------------------------------------------------------------
-# Uniformity check
+# Max fold fraction (dominant-fold check)
 # ---------------------------------------------------------------------------
 
-class TestUniformityCheck:
+class TestMaxFoldFraction:
+    """Verify that max_fold_fraction is correctly computed in fold_info."""
 
-    def test_uniform_signal_passes(self):
-        power = np.ones((5, 100), dtype=np.float32) * 10.0
-        U, passed = uniformity_check(power, 0, np.array([10, 20, 30, 40, 50]), 0.25)
-        assert U == pytest.approx(1.0)
-        assert passed is True
+    def test_uniform_signal_low_fraction(self):
+        """Equal-power folds should produce max_fold_fraction = 1/K."""
+        on_powers = np.ones(K) * 10.0
+        mff = float(np.max(on_powers) / np.sum(on_powers))
+        assert mff == pytest.approx(1.0 / K, rel=1e-5)
 
-    def test_one_hot_fails(self):
-        power = np.ones((5, 100), dtype=np.float32) * 0.01
-        power[2, 50] = 100.0  # one strong window
-        U, passed = uniformity_check(power, 2, np.array([10, 20, 50, 40, 30]), 0.25)
-        assert U < 0.25
-        assert passed is False
+    def test_one_hot_high_fraction(self):
+        """One dominant fold should produce max_fold_fraction near 1.0."""
+        on_powers = np.ones(K) * 0.01
+        on_powers[2] = 100.0
+        mff = float(np.max(on_powers) / np.sum(on_powers))
+        assert mff > 0.95
 
-    def test_boundary_passes(self):
-        power = np.ones((5, 100), dtype=np.float32)
-        # min/max ratio = 0.25 exactly
-        power[0, 10] = 4.0
-        power[0, 20] = 1.0
-        power[0, 30] = 2.0
-        power[0, 40] = 3.0
-        power[0, 50] = 2.0
-        U, passed = uniformity_check(power, 0, np.array([10, 20, 30, 40, 50]), 0.25)
-        assert U == pytest.approx(0.25)
-        assert passed is True
-
-    def test_boundary_just_below_fails(self):
-        power = np.ones((5, 100), dtype=np.float32)
-        power[0, 10] = 5.0
-        power[0, 20] = 1.0  # ratio = 0.2
-        power[0, 30] = 3.0
-        power[0, 40] = 3.0
-        power[0, 50] = 3.0
-        U, passed = uniformity_check(power, 0, np.array([10, 20, 30, 40, 50]), 0.25)
-        assert U < 0.25
-        assert passed is False
-
-    def test_zero_power_fails(self):
-        power = np.zeros((5, 100), dtype=np.float32)
-        U, passed = uniformity_check(power, 0, np.array([10, 20, 30, 40, 50]), 0.25)
-        assert U == 0.0
-        assert passed is False
+    def test_moderate_variation_below_threshold(self):
+        """Real-world power variation (e.g. 62-81 dB) should be well below 0.8."""
+        # Simulate the real-world case from logs
+        on_powers = np.array([3.858e-03, 4.892e-03, 5.726e-03, 2.893e-02,
+                              2.649e-01, 2.802e-01, 4.865e-02, 1.119e-01,
+                              5.899e-02, 5.587e-02, 4.953e-02, 4.277e-02,
+                              5.757e-02, 6.722e-02, 6.539e-02, 3.279e-02,
+                              2.956e-02, 2.576e-02, 2.378e-02, 1.773e-02])
+        mff = float(np.max(on_powers) / np.sum(on_powers))
+        assert mff < 0.3  # 0.22 in practice
+        assert mff < 0.8  # well below dominant-fold threshold
 
 
 # ---------------------------------------------------------------------------
@@ -452,8 +493,7 @@ class TestFoldDetectEndToEnd:
 
         detections, _, _ = fold_detect(
             power, N_A, 5e-2, self.FS, nfft, n_w, n_ol, samples,
-            evt_cache, W=W, Wf=Wf, hypotheses=None, N_B=None,
-            min_uniformity=0.25)
+            evt_cache, W=W, Wf=Wf, hypotheses=None, N_B=None)
 
         assert len(detections) >= 1
         assert detections[0].hyp_label == "A"
@@ -485,8 +525,7 @@ class TestFoldDetectEndToEnd:
 
         detections, _, _ = fold_detect(
             power, N_A, 5e-2, self.FS, nfft, n_w, n_ol, samples,
-            evt_cache, W=W, Wf=Wf, hypotheses=hyps, N_B=N_B,
-            min_uniformity=0.25)
+            evt_cache, W=W, Wf=Wf, hypotheses=hyps, N_B=N_B)
 
         assert len(detections) >= 1
         # Should detect with a switch hypothesis (A_to_B_c2)
@@ -511,14 +550,14 @@ class TestFoldDetectEndToEnd:
         cache1 = {}
         det1, _, _ = fold_detect(
             power, N_A, 5e-2, self.FS, nfft, n_w, n_ol, samples,
-            cache1, W=W, Wf=Wf, hypotheses=None, min_uniformity=0.25)
+            cache1, W=W, Wf=Wf, hypotheses=None)
 
         # Run with explicit single-rate hypotheses
         hyps = build_hypothesis_indices(N_A, K, n_time, N_B=None)
         cache2 = {}
         det2, _, _ = fold_detect(
             power, N_A, 5e-2, self.FS, nfft, n_w, n_ol, samples,
-            cache2, W=W, Wf=Wf, hypotheses=hyps, min_uniformity=0.25)
+            cache2, W=W, Wf=Wf, hypotheses=hyps)
 
         # Both should detect (or not) at the same bins with same SNR
         assert len(det1) == len(det2)
@@ -527,8 +566,8 @@ class TestFoldDetectEndToEnd:
             assert det1[0].freq_hz == pytest.approx(det2[0].freq_hz, abs=1.0)
             assert det1[0].snr_db == pytest.approx(det2[0].snr_db, abs=0.5)
 
-    def test_uniformity_rejects_one_hot(self):
-        """A detection from a hypothesis where one window dominates should be rejected."""
+    def test_one_hot_has_dominant_fold(self):
+        """A one-hot signal should produce max_fold_fraction > 0.8."""
         N_A = 50
         n_time = 500
         n_freq = 20
@@ -536,13 +575,10 @@ class TestFoldDetectEndToEnd:
         rng = np.random.RandomState(77)
         power = rng.exponential(0.5, (n_freq, n_time)).astype(np.float32)
 
-        # Place signal in one window only at bin 5 — triggers detection
-        # but uniformity should reject it
+        # Place signal in one window only at bin 5
         signal_bin = 5
         t0 = 10
-        # Only boost the first window hugely
         power[signal_bin, t0] += 500.0
-        # Leave remaining windows at noise level
 
         hyps = build_hypothesis_indices(N_A, K, n_time, N_B=None)
 
@@ -552,54 +588,47 @@ class TestFoldDetectEndToEnd:
         n_ol_fake = 29
         det, _, _ = fold_detect(
             power, N_A, 5e-2, 3840.0, n_freq, n_w_fake, n_ol_fake,
-            n_time * 29 + 29, evt_cache, hypotheses=hyps,
-            min_uniformity=0.25)
+            n_time * 29 + 29, evt_cache, hypotheses=hyps)
 
-        # The one-hot signal bin must be rejected by uniformity.
-        # Other bins may still appear due to the trivially low threshold,
-        # but the injected one-hot bin must not survive.
+        # The one-hot signal bin should be detected (not rejected)
+        # but must have max_fold_fraction > 0.8 indicating a dominant fold.
         freq_axis = np.fft.fftshift(np.fft.fftfreq(n_freq, d=1.0 / 3840.0))
         signal_freq = freq_axis[signal_bin]
+        found_one_hot = False
         for d in det:
-            freq_hz = d[0]
-            assert abs(freq_hz - signal_freq) > 1.0, (
-                f"One-hot detection at signal bin freq={signal_freq:.1f} Hz "
-                f"should have been rejected by uniformity filter"
-            )
+            if abs(d.freq_hz - signal_freq) < 1.0:
+                found_one_hot = True
+                assert d.fold_info['max_fold_fraction'] > 0.8, (
+                    f"One-hot detection should have max_fold_fraction > 0.8, "
+                    f"got {d.fold_info['max_fold_fraction']:.3f}"
+                )
+        assert found_one_hot, "One-hot signal bin should be detected (not discarded)"
 
-    def test_all_detections_filtered_returns_best_cand(self):
-        """When all det_bins pass threshold but all are rejected by uniformity,
-        fold_detect must return best_cand without crashing (regression for
-        UnboundLocalError on best_cand)."""
+    def test_detection_not_discarded(self):
+        """Detections are never discarded by fold quality — only downgraded.
+        A one-hot spike that exceeds threshold must still be returned."""
         N_A = 50
         n_time = 500
         n_freq = 20
 
-        # Low-variance noise so only our injected bin exceeds threshold
         power = np.ones((n_freq, n_time), dtype=np.float32) * 0.5
 
-        # Inject a one-hot spike: huge power in one window only at one bin.
-        # This will exceed threshold but fail uniformity (min/max ≈ 0).
         signal_bin = 5
         power[signal_bin, 10] = 5000.0
 
         hyps = build_hypothesis_indices(N_A, K, n_time, N_B=None)
 
-        # Set threshold low enough that only the one-hot bin exceeds it,
-        # but high enough that pure-noise bins stay below.
         evt_cache = {'threshold': 50.0}
         n_w_fake = 58
         n_ol_fake = 29
         det, noise_psd, best_cand = fold_detect(
             power, N_A, 5e-2, 3840.0, n_freq, n_w_fake, n_ol_fake,
-            n_time * 29 + 29, evt_cache, hypotheses=hyps,
-            min_uniformity=0.5)
+            n_time * 29 + 29, evt_cache, hypotheses=hyps)
 
-        # All detections filtered — should return empty list + best_cand
-        assert det == []
-        assert best_cand is not None
-        assert 'freq_hz' in best_cand
-        assert 'score_ratio' in best_cand
+        # Detection should NOT be filtered out — fold quality only affects
+        # confidence, not whether the detection is returned.
+        assert len(det) >= 1
+        assert det[0].fold_info['max_fold_fraction'] > 0.8
 
 
 # ---------------------------------------------------------------------------

--- a/detector/tests/test_rate_switch.py
+++ b/detector/tests/test_rate_switch.py
@@ -19,6 +19,7 @@ import pytest
 from pulse_detector import (
     K,
     Detection,
+    DOMINANT_FOLD_THRESHOLD,
     FOLD_LOCAL_RADIUS,
     HYP_GROUP_IND_A,
     HYP_GROUP_IND_B,
@@ -633,7 +634,46 @@ class TestFoldDetectEndToEnd:
         # Detection should NOT be filtered out — fold quality only affects
         # confidence, not whether the detection is returned.
         assert len(det) >= 1
-        assert det[0].fold_info['max_fold_fraction'] > 0.8
+        assert det[0].fold_info['max_fold_fraction'] > DOMINANT_FOLD_THRESHOLD
+
+    def test_one_hot_yields_subthreshold_confidence(self):
+        """A one-hot spike with high score_ratio should still be classified as
+        SUBTHRESHOLD because max_fold_fraction exceeds DOMINANT_FOLD_THRESHOLD.
+        This tests the confidence classification policy."""
+        N_A = 50
+        n_time = 500
+        n_freq = 20
+
+        power = np.ones((n_freq, n_time), dtype=np.float32) * 0.5
+        signal_bin = 5
+        power[signal_bin, 10] = 5000.0
+
+        hyps = build_hypothesis_indices(N_A, K, n_time, N_B=None)
+        evt_cache = {'threshold': 50.0}
+        det, _, _ = fold_detect(
+            power, N_A, 5e-2, 3840.0, n_freq, 58, 29,
+            n_time * 29 + 29, evt_cache, hypotheses=hyps)
+
+        assert len(det) >= 1
+        d = det[0]
+        # The detection has a high score_ratio (well above any confidence_ratio)
+        # but the dominant fold should trigger SUBTHRESHOLD classification.
+        has_dominant_fold = d.fold_info['max_fold_fraction'] > DOMINANT_FOLD_THRESHOLD
+        assert has_dominant_fold, (
+            f"Expected dominant fold (>{DOMINANT_FOLD_THRESHOLD}), "
+            f"got {d.fold_info['max_fold_fraction']:.3f}")
+        assert d.score_ratio > 1.3, (
+            f"Expected high score_ratio for classification test, got {d.score_ratio:.3f}")
+        # Apply the same classification logic as the runtime reporting loop:
+        is_marginal = d.score_ratio < 1.3 or has_dominant_fold
+        assert is_marginal, "One-hot spike should be classified as marginal"
+        # Verify the derived outputs match expected policy:
+        # detection_status = SUBTHRESHOLD, confirmed_status = 0
+        from pulse_detector import DETECTION_STATUS_SUBTHRESHOLD
+        det_status = DETECTION_STATUS_SUBTHRESHOLD if is_marginal else 1
+        confirmed = 0 if is_marginal else 1
+        assert det_status == DETECTION_STATUS_SUBTHRESHOLD
+        assert confirmed == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

The old `min/max` uniformity filter was rejecting all detections at high SNR (U=0.014, threshold 0.25). Replace it with a `max(fold)/sum(fold)` fraction-of-sum diagnostic (matching uavrt_detection's `selectpeakindex`). Values > 0.8 downgrade confidence instead of discarding detections. Add Occam preference: if a switch hypothesis wins but the corresponding pure hypothesis scores within 5%, prefer the pure one.

### Changes

- **pulse_detector.py**: Remove `uniformity_check()` and `--min-uniformity` CLI arg. Add `max_fold_fraction` diagnostic. Add `OCCAM_MARGIN` Occam preference for pure hypotheses.
- **CommandHandler.cpp/h**: Remove `--min-uniformity 0.25` from detector command line. Thread `debug_detector` from GCS through to `--debug` flag.
- **test_rate_switch.py**: Replace uniformity tests with max-fold-fraction and Occam tests (46 tests pass).
- **test_end_to_end.py**: Remove broken `min_uniformity=` references (31 tests pass).
- **Documentation**: Update 3 markdown files to reflect new behavior.
- **tunnel-protocol**: Submodule updated (`debug_detector` field added).

### Testing

- 46/46 rate-switch tests pass
- 31/31 end-to-end tests pass
- C++ build passes, 5/5 C++ tests pass