### PR TITLE
Track vehicle time internally instead of calling settimeofday

### DIFF
--- a/controller/LogFileManager.cpp
+++ b/controller/LogFileManager.cpp
@@ -57,9 +57,9 @@ void LogFileManager::_createLogDir(LogFileManager::LogType_t logType)
         break;
     }
 
-    // rPi time should be synchronized with vehicle time
-    auto vehicleTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    auto vehicleTimeUTC = *std::gmtime(&vehicleTime);
+    auto vehicleTime = MavlinkSystem::instance()->vehicleTimeNow();
+    struct tm vehicleTimeUTC;
+    gmtime_r(&vehicleTime, &vehicleTimeUTC);
 
     char buffer[80];
     std::strftime(buffer, sizeof(buffer), "%Y-%m-%d_%H-%M-%S", &vehicleTimeUTC);

--- a/controller/MavlinkSystem.cpp
+++ b/controller/MavlinkSystem.cpp
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <fstream>
 #include <functional>
-#include <sys/time.h>
+#include <cstdlib>
 
 static MavlinkSystem* _instance = nullptr;
 
@@ -241,31 +241,53 @@ void MavlinkSystem::_sendMessageOnConnection(const mavlink_message_t& message)
 	_connection->_sendMessage(message);
 }
 
+std::time_t MavlinkSystem::vehicleTimeNow() const
+{
+	if (!_vehicleTimeReceived.load()) {
+		return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	}
+
+	std::scoped_lock<std::mutex> lock(_vehicleTimeMutex);
+	auto elapsed = std::chrono::steady_clock::now() - _vehicleTimeReceivedAt;
+	auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+	return static_cast<std::time_t>(_vehicleEpochSeconds + elapsedSeconds);
+}
+
 void MavlinkSystem::_handleSystemTime(const mavlink_message_t& message)
 {
-	static bool timeSetFailed = false;
-    mavlink_system_time_t system_time;
+	mavlink_system_time_t system_time;
+	mavlink_msg_system_time_decode(&message, &system_time);
 
-	if (timeSetFailed) {
+	if (system_time.time_unix_usec == 0) {
 		return;
 	}
 
-	mavlink_msg_system_time_decode(&message, &system_time);
-
 	auto vehicleEpochTimeSeconds = system_time.time_unix_usec / 1000000;
-	auto vehicleEpochTimeT = static_cast<std::time_t>(vehicleEpochTimeSeconds);
+	uint64_t previousEpochSeconds;
 
-    auto rpiEpochTimeT = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	{
+		std::scoped_lock<std::mutex> lock(_vehicleTimeMutex);
+		previousEpochSeconds = _vehicleEpochSeconds;
+		_vehicleEpochSeconds = vehicleEpochTimeSeconds;
+		_vehicleTimeReceivedAt = std::chrono::steady_clock::now();
+	}
 
-	if (static_cast<uint64_t>(vehicleEpochTimeT) != static_cast<uint64_t>(rpiEpochTimeT)) {
-		struct timeval tv;
-
-		logInfo() << "Synchronizing rPi time to vehicle time";
-		tv.tv_sec = static_cast<uint64_t>(vehicleEpochTimeT);
-		tv.tv_usec = 0;
-		if (settimeofday(&tv, NULL) != 0) {
-			timeSetFailed = true;
-			logError() << "Failed to set rPi time of day: " << strerror(errno);
+	if (!_vehicleTimeReceived.exchange(true)) {
+		auto t = static_cast<std::time_t>(vehicleEpochTimeSeconds);
+		struct tm tm_buf;
+		char buf[32];
+		gmtime_r(&t, &tm_buf);
+		std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &tm_buf);
+		logInfo() << "Vehicle time tracking started - " << buf << " (will update as GPS locks)";
+	} else if (previousEpochSeconds > 0) {
+		int64_t delta = static_cast<int64_t>(vehicleEpochTimeSeconds) - static_cast<int64_t>(previousEpochSeconds);
+		if (std::abs(delta) > 60) {
+			auto t = static_cast<std::time_t>(vehicleEpochTimeSeconds);
+			struct tm tm_buf;
+			char buf[32];
+			gmtime_r(&t, &tm_buf);
+			std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S UTC", &tm_buf);
+			logInfo() << "Vehicle time jumped by " << delta << "s (GPS lock?) - now " << buf;
 		}
 	}
 }

--- a/controller/MavlinkSystem.h
+++ b/controller/MavlinkSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <queue>
 #include <mutex>
@@ -50,6 +51,8 @@ public:
 	void						setHeartbeatStatus			(uint16_t heartbeatStatus) { _heartbeatStatus.store(heartbeatStatus); }
 	uint32_t					detectionMode				() const { return _detectionMode.load(); }
 	void						setDetectionMode			(uint32_t mode) { _detectionMode.store(mode); }
+	std::time_t					vehicleTimeNow				() const;
+	bool						vehicleTimeAvailable		() const { return _vehicleTimeReceived.load(); }
 
 private:
 	MavlinkSystem();
@@ -67,6 +70,10 @@ private:
 	Telemetry 					_telemetry;
 	std::atomic<uint16_t>		_heartbeatStatus { HEARTBEAT_STATUS_IDLE };
 	std::atomic<uint32_t>		_detectionMode { DETECTION_MODE_UAVRT };
+	std::atomic<bool>			_vehicleTimeReceived { false };
+	uint64_t					_vehicleEpochSeconds { 0 };
+	std::chrono::steady_clock::time_point _vehicleTimeReceivedAt {};
+	mutable std::mutex			_vehicleTimeMutex {};
 
 	friend class MavlinkOutgoingMessageQueue;
 };


### PR DESCRIPTION
## Summary

Replace `settimeofday()` time sync with internal vehicle time tracking. This avoids permission issues on the RPi while ensuring log folder timestamps correlate with PX4 ULG flight logs.

## Changes

- **MavlinkSystem.h/cpp** — Store vehicle epoch time from `SYSTEM_TIME` messages. Expose `vehicleTimeNow()` which returns vehicle time adjusted by local elapsed `steady_clock` time. Falls back to `system_clock` if no vehicle time received yet.
- **LogFileManager.cpp** — Use `vehicleTimeNow()` instead of `system_clock::now()` for log folder timestamps.
- Removed `settimeofday()` and `#include <sys/time.h>`.
- Used `gmtime_r()` instead of `gmtime()` for thread safety.
- Logs human-readable time on first receipt and detects GPS lock via >60s time jumps.